### PR TITLE
Revise client-controlled sync requirements

### DIFF
--- a/design/sync.md
+++ b/design/sync.md
@@ -16,4 +16,4 @@ Suppose we have three processes: A, B and C. From the point of view of A, we kno
 
 After each tick on the client/editor, clients/editors send a list of changes to their own state to the server. After each tick on the server, the server sends a list of all changes it has seen to all other processes. Processes ignore changes reported for data that they own, since it may be less recent than their own state.
 
-By default, every view is owned by the server. Views tagged "editor" are owned by the editor. Views tagged "client" are partitioned by session id - each client owns only the rows corresponding to it's own session id. If a view is tagged client, it must have exactly one field tagged "session". These tags must be set when a view is created and never changed.
+By default, every view is owned by the server. Views tagged "editor" are owned by the editor. Views tagged "client" are partitioned by session id - each client owns only the rows corresponding to it's own session id. If a view is tagged client, it must have a field tagged "session". These tags must be set when a view is created and never changed.


### PR DESCRIPTION
Add a robust and obvious solution for detecting the session field.
Blocks: #48 
