### PR TITLE
Run the commands in the background.

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -16,9 +16,9 @@ popd
 # If we aren't restarting, open the editor in the user's preferred browser
 if [[ "x$1" != "x--restart" ]]; then
   if [[ "$OSTYPE" == "darwin"* ]]; then
-    open "$waitUrl"
+    open "$waitUrl" &
   else
-    xdg-open "$waitUrl"
+    xdg-open "$waitUrl" &
   fi
 fi
 


### PR DESCRIPTION
On my system, run.sh doesn't work, becuase opening the browser blocks
the server from getting started. Adding a & backgrounds the open.