### PR TITLE
Fix install instruction to match actual file name

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -11,7 +11,7 @@ if [ $? -ne 0 ]; then
 fi
 hash multirust 2>/dev/null
 if [ $? -ne 0 ]; then
-  echo "Please install multirust with ('./install-multirust') before continuing."
+  echo "Please install multirust with ('./install-multirust.sh') before continuing."
   exit
 fi
 


### PR DESCRIPTION
The installation instruction does not currently match the actual script name. This resolves it so users can copy & paste command.