### PR TITLE
Ensure the searcher has a larger z-index than welcome buttons

### DIFF
--- a/ui/css/editor.css
+++ b/ui/css/editor.css
@@ -194,7 +194,7 @@ input[type="text"], textarea { font-family: "Lato"; font-size: 16px; }
 - Searcher
 ---------------------------------------------------------*/
 
-.searcher-container { position:absolute; top:0; bottom:0; left:0; right: 0; z-index: 10; }
+.searcher-container { position:absolute; top:0; bottom:0; left:0; right: 0; z-index: 20; }
 .searcher-shade { position:absolute; top:0; bottom:0; left:0; right:0; }
 .searcher { position:absolute; z-index: 10; bottom:0; left:0; background:#444; box-shadow:0 0 8px #000; }
 .searcher .search-box { outline: none; height: 64px; padding: 10px; background: transparent; border: none; vertical-align: top; }


### PR DESCRIPTION
Currently, the "New" and "Import" buttons in the welcome message show above the searcher, if they should overlap.  This seems to be because both the buttons and the searcher are given a z-index of 10 and the buttons show up later in the DOM.  I'm guessing that there's a reason the buttons must have the z-index they do, so I've upped the z-index of the searcher-container to ensure it's comfortably over the buttons.