### PR TITLE
Force to string before using localeCompare

### DIFF
--- a/ui/src/tableEditor.ts
+++ b/ui/src/tableEditor.ts
@@ -86,7 +86,7 @@ module tableEditor {
         if(typeA === "undefined") { return -1; }
         if(typeB === "undefined") { return 1; }
         if(a.constructor === Array) { return JSON.stringify(a).localeCompare(JSON.stringify(b)); }
-        return a.localeCompare(b);
+        return a.toString().localeCompare(b.toString());
       });
     }
     rows.forEach(function(cur, rowIx) {


### PR DESCRIPTION
This follows the suggestion in #232, which seems sensible to me.