### PR TITLE
Allow importing falsey values from CSV

### DIFF
--- a/ui/src/editor.ts
+++ b/ui/src/editor.ts
@@ -1504,7 +1504,7 @@ module drawn {
           }
           var factMap = {};
           for(var fieldIx = 0; fieldIx < info.mapping.length; fieldIx++) {
-            factMap[info.mapping[fieldIx]] = row[fieldIx] || "";
+            factMap[info.mapping[fieldIx]] = (row[fieldIx] === undefined) ? "" : row[fieldIx];
           }
           facts.push(factMap);
         }


### PR DESCRIPTION
The existing import code changed all falsey values to empty string.  It looks like we need to do that to undefined, but other values, like 0 or false, should be let through as-is.

This was reported in #242.