### PR TITLE
Keep buttons from stretching to fill width of parent

### DIFF
--- a/ui/css/editor.css
+++ b/ui/css/editor.css
@@ -159,6 +159,7 @@ input[type="text"], textarea { font-family: "Lato"; font-size: 16px; }
 .settings-modal .pane { max-height: 90vh; min-height: 10vh; padding-top: 10px; }
 .settings-modal .h3 { text-align: left; align-self: stretch; }
 .settings-modal .saves > * { padding: 10px; align-self: stretch; min-width: 208px; }
+.settings-modal .input-row > .button { align-self: flex-start; }
 
 .tabbed-modal { padding: 0 !important; }
 
@@ -173,6 +174,7 @@ input[type="text"], textarea { font-family: "Lato"; font-size: 16px; }
 
 .import-panel .pane > * { margin-top:10px; }
 .import-panel .flex-row { align-items: center; }
+.import-panel .button { align-self: flex-start; }
 
 /*---------------------------------------------------------
 - Sorter

--- a/ui/src/editor.ts
+++ b/ui/src/editor.ts
@@ -2611,7 +2611,7 @@ module drawn {
             {text: "Treat first row as header"},
             {t: "input", type: "checkbox", change: updateCsvHasHeader}
           ]},
-          {c: "button", text: "import", click: importFromCsv}
+          {c: "button", text: "Import", click: importFromCsv}
         ]
       }
     ]};


### PR DESCRIPTION
I have trouble reading the buttons that stretch all the way across a pane as buttons.  They look much more like text areas to me.  Letting them take a natural width is enough to make them look like buttons.  Maybe I'm just weird, but here's a patch to change that, in case it bothers other people too.

This patch targets specific buttons with relatively specific CSS selectors.  We could get the same effect, as of now, by settings `align-self: flex-start` on all `.button`s.  This might give us undesired results if buttons of different natural heights are in a horizontal container.  I don't know if that's something we should worry about or not.

I also snuck in a change in capitalization of a button label.