### PR TITLE
Clean up run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,36 +1,72 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-waitUrl="`pwd`/ui/waiting-room.html";
+waitUrl="$(pwd)/ui/waiting-room.html";
+rustVersion="nightly-2015-08-10"
+debugFlag=false
+noBrowserFlag=false
 
-# Ensure dependencies are installed.
-echo "* Checking dependencies..."
-hash tsc 2>/dev/null
-if [ $? -ne 0 ]; then
-  echo "Please install the typescript compiler with ('sudo npm install -g typescript') before continuing."
-  exit
-fi
-hash multirust 2>/dev/null
-if [ $? -ne 0 ]; then
-  echo "Please install multirust with ('./install-multirust.sh') before continuing."
-  exit
-fi
+# Parse command line options.
+while test $# -gt 0; do
+case "$1" in
+  -h|--help)
+    echo "Compile and run the Eve editor"
+    echo ""
+    echo "Usage:"
+    echo "    run.sh [options]"
+    echo ""
+    echo "Options:"
+    echo "    -h, --help          Print this message"
+    echo "    -d, --debug         Debug build"
+    echo "    -n, --no-browser    Do not open editor in browser"
+    exit 0
+    ;;
+  -d|--debug)
+    debugFlag=true
+    shift
+    ;;
+  -n|--no-browser)
+    noBrowserFlag=true
+    shift
+    ;;
+  *)
+    break
+    ;;
+esac
+done
 
-pushd .
-  # Try using the typescript compiler (tsc) to compile UI
-  echo "* Compiling Editor..."
-  cd ui
-
-  tsc
-  if [ $? -ne 0 ]; then
-   echo "Failed to compile editor, bailing."
-   popd
-   exit
+# Ensure that dependencies are installed.
+printf "* Checking dependencies..."
+deps="tsc multirust"
+for dep in $deps; do
+  if ! which "$dep" &> /dev/null; then
+    printf "\n  x Please install %s: " "$dep"
+    if [ "$dep" = "tsc" ]; then
+      echo "sudo npm install -g typescript"
+    elif [ "$dep" = "multirust" ]; then
+      echo "./install-multirust"
+    fi
+    exit 1
   fi
-popd
+done
+echo "done."
 
-# If we aren't restarting, open the editor in the user's preferred browser
-if [[ "x$1" != "x--restart" ]]; then
-  echo "* Opening $waitUrl"
+# Try using the TypeScript compiler (tsc) to compile UI.
+pushd . &> /dev/null
+  printf "* Compiling editor..."
+  cd ui
+  tscError=$(tsc)
+  if [ $? -ne 0 ]; then
+    printf "\n  x %s\n" "$tscError"
+    popd &> /dev/null
+    exit 1
+  else
+    echo "done."
+  fi
+popd &> /dev/null
+
+# If noBrowserFlag is false open the editor in the user's preferred browser.
+if ! $noBrowserFlag; then
+  echo "* Opening editor: $waitUrl"
   if [[ "$OSTYPE" == "darwin"* ]]; then
     open "$waitUrl" &
   else
@@ -38,18 +74,33 @@ if [[ "x$1" != "x--restart" ]]; then
   fi
 fi
 
-pushd .
-  # Ensure rustc is updated
-  echo "* Updating rust if necessary..."
+pushd . &> /dev/null
   cd runtime
-  multirust override nightly-2015-08-10
 
-  # Compile runtime server
-  echo "* Compiling server... (This takes a while)"
+  # Ensure Rust is updated.
+  multirust list-toolchains | grep "$rustVersion" &> /dev/null
+  if [ $? -eq 0 ]; then
+    echo "* Rust is up to date."
+    multirust override "$rustVersion" &> /dev/null
+  else
+    printf "* Updating Rust..."
+    multirustOutputFile="multirust-output.log"
+    multirust override "$rustVersion" &> "$multirustOutputFile"
+    if [ $? -ne 0 ]; then
+      cat "$multirustOutputFile"
+      rm "$multirustOutputFile"
+      exit 1
+    else
+      echo "done."
+    fi
+  fi
+
+  # Compile and run server.
+  echo "* Compiling and running server. This takes a while..."
   rustFlags="--release"
-  if [[ "x$1" != "x--debug" ]]; then
+  if $debugFlag; then
     rustFlags=""
   fi
 
   RUST_BACKTRACE=1 cargo run --bin=server $rustFlags
-popd
+popd &> /dev/null


### PR DESCRIPTION
Clean up the following in run.sh:
* Fix shellcheck warnings.
* Switch to #!/usr/bin/env bash to use the current environment's bash.
* Parse command line flags.
* Add help message.
* Use for loop to dry code up when checking dependencies.
* Send pushd and popd stdout and stderr to /dev/null to declutter script output.
* Check multirust list-toolchains for existing install before overriding.
* Store multirust version in a variable.

Minor:
* Reword a few sentences.

<img width="745" alt="screen shot 2015-08-25 at 5 16 32 pm" src="https://cloud.githubusercontent.com/assets/10385848/9482826/11d5def6-4b4d-11e5-9288-698e26ea5762.png">

<img width="754" alt="screen shot 2015-08-25 at 3 51 04 pm" src="https://cloud.githubusercontent.com/assets/10385848/9481668/24637de6-4b41-11e5-8e47-96d7d2a8a8c8.png">