### PR TITLE
Move tooltips vertically to keep entirely on screen

### DIFF
--- a/ui/src/editor.ts
+++ b/ui/src/editor.ts
@@ -124,6 +124,14 @@ module drawn {
         }
     }
 
+    // Move the node vertically to ensure it doesn't run off the bottom on the screen.
+    function ensureOnscreen(node, elem) {
+      let maxTop = Math.max(document.documentElement.clientHeight, window.innerHeight || 0) - node.offsetHeight;
+      if(node.offsetTop > maxTop) {
+        node.style.top = maxTop;
+      }
+    }
+
 	//---------------------------------------------------------
   // Renderer
   //---------------------------------------------------------
@@ -1539,7 +1547,8 @@ module drawn {
             info.disabledMessage ? {c: "disabled-message", text: "Disabled because " + info.disabledMessage} : undefined,
           ]},
           x: info.x + 5,
-          y: info.y
+          y: info.y,
+          postRender: ensureOnscreen
         };
         if(!localState.tooltip) {
           localState.tooltipTimeout = setTimeout(function() {
@@ -2508,8 +2517,6 @@ module drawn {
   export function tooltipUi(): any {
     let tooltip = localState.tooltip;
     if(tooltip) {
-      let viewHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-       // @FIXME: We need to get the actual element size here.
       let elem:any = {c: "tooltip" + (tooltip.c ? " " + tooltip.c : ""), left: tooltip.x, top: tooltip.y};
       if(typeof tooltip.content === "string") {
         elem["text"] = tooltip.content;
@@ -2517,6 +2524,9 @@ module drawn {
         elem["children"] = [tooltip.content()];
       } else {
         elem["children"] = [tooltip.content];
+      }
+      if(tooltip.postRender) {
+        elem["postRender"] = tooltip.postRender;
       }
       if(tooltip.persistent) {
         return {id: "tooltip-container", c: "tooltip-container", children: [


### PR DESCRIPTION
To address #252.

A few potential issues:
- Performance on Firefox can be poor, with the post-render step taking 35-40 ms.  This doesn't seem to be a problem in Chrome.  I don't understand the difference.
- If a tooltip runs off the bottom, it gets moved to align with the bottom.  Perhaps it should be moved a bit further so the drop shadow is visible?
- Only vertical position is considered.  Should we also worry about these running off the right of the screen?  This would require a bit more logic to avoid drawing the tooltip over top of the button.
- I only trigger this for things created by "showButtonTooltip".  Perhaps it should happen for everything created by "showTooltip"?  I don't understand the distinction between these two things.