### PR TITLE
Git hook requires /bin/bash

### DIFF
--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # An example hook script to verify what is about to be pushed.  Called by "git
 # push" after it has checked the remote status, but before anything has been


### PR DESCRIPTION
Since it uses `[[` comparisons.