### PR TITLE
Add in line numbere

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
       .CodeMirror .STRING, .STRING_OPEN, .STRING_CLOSE, .BOOLEAN, .NUMBER { color: #ff66ac; color: #acaaff; }
       .CodeMirror .OPEN_BRACKET, .CodeMirror .DOT, .CodeMirror .CLOSE_BRACKET, .CodeMirror .OPEN_PAREN, .CodeMirror .CLOSE_PAREN, .CodeMirror .ALIAS, .CodeMirror .EQUALITY, .CodeMirror .SET, .CodeMirror .INSERT, .CodeMirror .REMOVE, .CodeMirror .INFIX, .CodeMirror .COMMA { color: gray; }
       .CodeMirror .BLOCK_OPEN, .CodeMirror .BLOCK_CLOSE { color: gray; }
+      .CodeMirror .CodeMirror-gutters { background-color: rgb(47,47,49); }
     </style>
   </head>
   <body>

--- a/jssrc/renderer.js
+++ b/jssrc/renderer.js
@@ -708,6 +708,7 @@ function injectCodeMirror(node, elem) {
     let editor = new CodeMirror(node, {
       tabSize: 2,
       lineWrapping: true,
+      lineNumbers: true,
       extraKeys: {
         "Cmd-Enter": doSwap,
         "Ctrl-Enter": doSwap,


### PR DESCRIPTION
Line numbers are not included in the included Eve editor.

Line numbers are important because error messages list line numbers as reference point to finding the location of the error. They are particularly important if someone is using their own tooling.
![nolinenumbers](https://cloud.githubusercontent.com/assets/1957315/17667998/611e700e-62d5-11e6-8a7b-bf1795b8fd3f.png)

The editor is more pleasing to the eye without line numbers, but due to the current errors reporting line numbers I feel that they are important to include. (This could also be solved by a 'take me to this error button'.) I fooled around with the idea of only including the line numbers on the 'code' lines, but it required hacky CSS code that I was not comfortable with.