### PR TITLE
Implement range[from? to? increment? return]

### DIFF
--- a/src/runtime/providers/math.ts
+++ b/src/runtime/providers/math.ts
@@ -240,6 +240,49 @@ class Random extends Constraint {
   }
 }
 
+class Range extends Constraint {
+  static AttributeMapping = {
+    "from": 0,
+    "to": 1,
+    "increment": 2,
+  }
+
+  resolveProposal(proposal, prefix) {
+    let {args} = this.resolve(prefix);
+    let from_ = args[0];
+    let to = args[1];
+    let increment = args[2] || 1;
+    let results = [];
+    let test = from_ <= to ? (val) => val <= to : (val) => val >= to;
+    for (let val = from_; test(val); val += increment) {
+      results.push(val);
+    }
+    return results;
+  }
+
+  test(prefix) {
+    let {args, returns} = this.resolve(prefix);
+    let from_ = args[0];
+    let to = args[1];
+    let increment = args[2] || 1;
+    let val = returns[0];
+    let member = from_ <= val && val <= to &&
+                 ((val - from_) % increment) == 0
+    return member;
+  }
+
+  getProposal(tripleIndex, proposed, prefix) {
+    let {args} = this.resolve(prefix);
+    let from_ = args[0];
+    let to = args[1];
+    let increment = args[2] || 1;
+    let proposal = this.proposalObject;
+    proposal.providing = proposed;
+    proposal.cardinality = Math.ceil((to - from_ + 1) / increment);
+    return proposal;
+  }
+}
+
 providers.provide("+", Add);
 providers.provide("-", Subtract);
 providers.provide("*", Multiply);
@@ -250,3 +293,4 @@ providers.provide("floor", Floor);
 providers.provide("abs", Abs);
 providers.provide("mod", Mod);
 providers.provide("random", Random);
+providers.provide("range", Range);


### PR DESCRIPTION
I have implemented range[] so I can update my Eve programs to work with the ts-merge branch. I think I've implemented the correct behaviour for here. I used the following program plus adding some trace to manually check it works.

```
commit
  [#birthday age: -2]
  [#birthday age: 3]
  [#birthday age: 8]
  [#birthday age: 13]
  [#birthday age: 18]
  [#birthday age: 20]
  [#birthday age: 21]
  [#birthday age: 23]
  [#birthday age: 30]
  [#birthday age: 30]
  [#birthday age: 40]
  [#birthday age: 42]
  [#birthday age: 60]
  [#birthday age: 64]
```
```
search
  birthday = [#birthday not(cake-type)]
commit
  birthday.cake-type := "normal"
```
```
search
  birthday = [#birthday cake-type age]
  age = range[from: 1 to: 12]
commit
  birthday.cake-type := "special"
```
```
search
  birthday = [#birthday cake-type age]
  age = range[from: 12 to: 21 increment: 3]
commit
  birthday.cake-type := "special"
```
```
search
  birthday = [#birthday cake-type age]
  age = range[from: 5 to: 25 increment: 5]
commit
  birthday.cake-type := "special"
```
```
search
  birthday = [#birthday cake-type age]
  age = range[from: 20 to: 120 increment: 10]
commit
  birthday.cake-type := "special"
```
```
search
  birthday = [#birthday cake-type age]
  age = range[from: 0 to: -5 increment: -1]
commit
  birthday.cake-type := "really special"
```
```
search
  birthday = [#birthday cake-type age]
bind @browser
  [#div sort: age text: "{{age}} {{cake-type}}"]