### PR TITLE
Correct anti-diagonal scoring in tic-tac-toe example

### DIFF
--- a/examples/tic-tac-toe.eve
+++ b/examples/tic-tac-toe.eve
@@ -43,14 +43,14 @@ Now we tag some special cell groupings: diagonal and anti-diagonal cells. The di
 
 Similarly, the anti-diagonal cells are (1, 3), (2, 2), and (3, 1).
 
-Anti-diagonal cells satisfy the equation `row + col = N - 1`,
+Anti-diagonal cells satisfy the equation `row + col = N + 1`,
 where N is the size of the board.
 
 ```
   search
     cells = [#cell row column]
     [#board size: N]
-    row + column = N - 1
+    row + column = N + 1
 
   bind
     cells += #anti-diagonal


### PR DESCRIPTION
Noticed that the language - and the code - was exactly backwards for this calculation (yay narrative), fixed it.