### PR TITLE
Add License and Repository fields, fixes annoying npm warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,5 +31,10 @@
     "start": "node ./build/src/runtime/server.js",
     "server": "node ./build/src/runtime/server.js",
     "test": "node ./build/test/all.js | faucet"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/witheve/Eve.git"
+  },
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Fixes the npm warnings when you npm install, saying no license or repository fields