### PR TITLE
Fix inspector

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -174,7 +174,8 @@ export class EveClient {
     }
   }
 
-  send(message:string) {
+  send(payload:{type: string, [attributes:string]: any}) {
+    let message = JSON.stringify(payload);
     if(!this.localEve) {
       this.socketSend(message);
     } else {
@@ -196,7 +197,7 @@ export class EveClient {
     for(let record of records) {
       eavs.push.apply(eavs, recordToEAVs(record));
     }
-    this.send(JSON.stringify({type: "event", insert: eavs}))
+    this.send({type: "event", insert: eavs})
   }
 
   onError() {
@@ -400,15 +401,15 @@ function initIDE(ide:IDE, client:EveClient) {
     console.groupCollapsed(`SENT ${generation}`);
     console.info(md);
     console.groupEnd();
-    client.send(JSON.stringify({scope: "root", type: "parse", generation, code: md}));
+    client.send({scope: "root", type: "parse", generation, code: md});
   }
   ide.onEval = (ide:IDE, persist) => {
-    client.send(JSON.stringify({type: "eval", persist}));
+    client.send({type: "eval", persist});
   }
   ide.onLoadFile = (ide, documentId, code) => {
-    client.send(JSON.stringify({type: "close"}));
-    client.send(JSON.stringify({scope: "root", type: "parse", code}))
-    client.send(JSON.stringify({type: "eval", persist: false}));
+    client.send({type: "close"});
+    client.send({scope: "root", type: "parse", code})
+    client.send({type: "eval", persist: false});
     let url = `${location.pathname}#${documentId}`;
     if(documentId.indexOf("/examples/") === -1) {
       url = `${location.pathname}#/examples/${documentId}`;
@@ -422,7 +423,7 @@ function initIDE(ide:IDE, client:EveClient) {
   }
 
   ide.onTokenInfo = (ide, tokenId) => {
-    client.send(JSON.stringify({type: "tokenInfo", tokenId}));
+    client.send({type: "tokenInfo", tokenId});
   }
 
   ide.loadWorkspace("examples", window["examples"]);

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2613,7 +2613,7 @@ export class IDE {
       if(record.span) {
         this.attachView(recordId, record.span[0]);
       } else if(record.node) {
-        client.send(JSON.stringify({type: "findNode", recordId, node: record.node[0]}));
+        client.send({type: "findNode", recordId, node: record.node[0]});
       } else {
         console.warn("Unable to parent view that doesn't provide its origin node  or span id", record);
       }

--- a/src/runtime/runtimeClient.ts
+++ b/src/runtime/runtimeClient.ts
@@ -95,8 +95,9 @@ export abstract class RuntimeClient {
     return true;
   }
 
-  handleEvent(json) {
+  handleEvent(json:string) {
     let data = JSON.parse(json);
+    if(typeof data !== "object") throw new Error(data);
     if(data.type === "event") {
       if(!this.evaluation) return;
       // console.info("EVENT", json);


### PR DESCRIPTION
Merging the client refactoring broke the inspector logic on local runtimes. The client was in some cases double-stringifying message payloads, resulting in failure to interpret some messages in the language service.