### PR TITLE
Fixed cursor reset when changing value of input.

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -217,7 +217,7 @@ export function renderRecords() {
         } else if(value.length > 1) {
           console.error("Unable to set 'value' multiple times on entity", entity, JSON.stringify(value));
         } else {
-          input.value = value[0]; // @FIXME: Should this really be setAttribute?
+          input.setAttribute('value', value[0]);
         }
 
       } else if(attribute === "checked") {


### PR DESCRIPTION
## Problem

Whenever changing an input's value, the cursor is reset to the end of the input. Not noticable unless you try to change something in an input value that is not at the end.

## How to reproduce

With the following Eve program:

```eve
commit @browser
  [#input]
```

Fill in the input with a string. Move the cursor to the beginning of the string (or anywhere not at the end). Write something. You'll see that it's impossible to add something without the cursor resetting to the end of the string.

## Solution

The solution is actually very simple, and hinted at in `renderer.ts`, simply use setAttribute instead of setting the input value directly.