### PR TITLE
Remove unnecessary condition in fullScan

### DIFF
--- a/src/runtime/join.ts
+++ b/src/runtime/join.ts
@@ -184,11 +184,7 @@ export class Scan {
     let solving = [];
     let solveNode = this.node !== undefined;
     let depth = solveNode ? 4 : 3;
-    if(a !== undefined) {
-      this._fullScanLookup(index.aveIndex, solving, results, [a,v,e,node], 0, 0, depth);
-    } else  {
-      this._fullScanLookup(index.eavIndex, solving, results, resolved, 0, 0, depth);
-    }
+    this._fullScanLookup(index.eavIndex, solving, results, resolved, 0, 0, depth);
     return results;
   }
 


### PR DESCRIPTION
There are two reasons to remove this condition.

1. It's not used. All conditions when `attribute` is present are
already coverered via index lookup in other branches of switch in `getProposal`
(`*a**`,`ea**`,`*av**`,`eav*`,`***n`).

2. It's broken. Default branch of switch (which corresponds to full scan) in
`getProposal` always populates `providing` in order of EAV, but if this
condition would ever run it would return values in order of AVE thus
breaking the assumptions of `joinRound` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/611)
<!-- Reviewable:end -->
