### PR TITLE
Fix not without dependencies

### DIFF
--- a/src/runtime/join.ts
+++ b/src/runtime/join.ts
@@ -503,7 +503,7 @@ export class NotScan {
     // nots won't get evaluated during Generic Join since we're never solving for a
     // variable that this scan cares about.
     if((!prejoin || this.args.length)
-       // if we are forcing and not solving for the current variable, then we just accept
+       // if we aren't forcing and not solving for the current variable, then we just accept
        // as it is
        && (!force && !this.internalVars[solvingFor.id] && this.internalVars.length)
        // we also blind accept if we have args that haven't been filled in yet, as we don't

--- a/src/runtime/join.ts
+++ b/src/runtime/join.ts
@@ -831,12 +831,22 @@ function preJoinAccept(multiIndex: MultiIndex, providers : ProposalProvider[], v
     if(value !== undefined && vars[ix] !== undefined) {
       presolved++;
       for(let provider of providers) {
-        if(!provider.accept(multiIndex, prefix, solvingFor)) {
+        if(!provider.accept(multiIndex, prefix, solvingFor, false, true)) {
           return {accepted: false, presolved};
         }
       }
     }
     ix++;
+  }
+  // if we haven't presolved anything, we still need to do a single prejoin pass
+  // to make sure that any nots that may have no external dependencies are
+  // given a chance to end this evaluation
+  if(presolved === 0) {
+    for(let provider of providers) {
+      if(provider instanceof NotScan && !provider.accept(multiIndex, prefix, {id: "0"}, false, true)) {
+        return {accepted: false, presolved};
+      }
+    }
   }
   return {accepted: true, presolved};
 }

--- a/test/join.ts
+++ b/test/join.ts
@@ -2647,7 +2647,7 @@ test("not can't provide a variable for an attribute access", (assert) => {
   assert.end();
 })
 
-test.only("not without dependencies filters correctly", (assert) => {
+test("not without dependencies filters correctly", (assert) => {
   let expected = {
     insert: [[1, "tag", "foo"]],
     remove: [],

--- a/test/join.ts
+++ b/test/join.ts
@@ -2647,6 +2647,29 @@ test("not can't provide a variable for an attribute access", (assert) => {
   assert.end();
 })
 
+test.only("not without dependencies filters correctly", (assert) => {
+  let expected = {
+    insert: [[1, "tag", "foo"]],
+    remove: [],
+  };
+  evaluate(assert, expected, `
+    add some stuff
+    ~~~
+    commit
+      [#foo]
+    ~~~
+
+    foo bar
+    ~~~
+    search
+      not([#foo])
+    bind
+      [#bar]
+    ~~~
+  `);
+  assert.end();
+})
+
 
 test("indirect constant equality in if", (assert) => {
   let expected = {


### PR DESCRIPTION
Currently nots that have no dependencies never get an opportunity to run since they are never solving for a variable. This PR adds a prejoin flag to accept and changes NotScan to force an accept check in the case when prejoin is true and the scan has no args. It also adds an extra step to the preJoinAccept function to check nots if they would otherwise not be.