### PR TITLE
Fix determining if a stratum has database scans

### DIFF
--- a/src/runtime/block.ts
+++ b/src/runtime/block.ts
@@ -141,8 +141,14 @@ function hasDatabaseScan(strata) {
   for(let stratum of strata) {
     for(let scan of stratum.scans) {
       if(scan instanceof Scan) return true;
-      if(scan instanceof IfScan) return true;
-      if(scan instanceof NotScan) return true;
+      if(scan instanceof IfScan) {
+        for(let branch of scan.branches) {
+          if(hasDatabaseScan(branch.strata)) return true;
+        }
+      }
+      if(scan instanceof NotScan) {
+        if(hasDatabaseScan(scan.strata)) return true;
+      }
     }
   }
   return false;


### PR DESCRIPTION
Ifs and nots can technically use only local variables and don't necessarily mean we have database scans. The practical implication of this is that any block that had an if or not in it always reran when evaling. This prevents purely static blocks from doing so.