### PR TITLE
Blank lookup in a search should produce error

### DIFF
--- a/src/runtime/builder.ts
+++ b/src/runtime/builder.ts
@@ -296,6 +296,11 @@ function buildScans(block, context, scanLikes, outputScans) {
         node = context.getValue(scanLike.node)
         context.provide(node);
       }
+
+      if(!(entity || attribute || value || node)) {
+        context.errors.push(errors.blankScan(block, scanLike));
+      }
+
       let final = new join.Scan(scanLike.id + "|build", entity, attribute, value, node, scanLike.scopes);
       outputScans.push(final);
       scanLike.buildId = final.id;

--- a/src/runtime/errors.ts
+++ b/src/runtime/errors.ts
@@ -198,6 +198,12 @@ export function unprovidedVariableGroup(block, variables) {
   return new EveError(id, start, stop, messages.unprovidedVariable(found.name));
 }
 
+export function blankScan(block, scan) {
+  let {id, start: blockStart} = block;
+  let [start, stop] = parser.nodeToBoundaries(scan, blockStart);
+  return new EveError(id, start, stop, messages.blankScan());
+}
+
 export function invalidLookupAction(block, action) {
   let {id, start: blockStart} = block;
   let [start, stop] = parser.nodeToBoundaries(action, blockStart);
@@ -257,6 +263,7 @@ export var messages = {
 
   unimplementedExpression: (op) => `There's no definition for the function ${op}`,
 
+  blankScan: () => 'Lookup requires at least one attribute: record, attribute, value, or node',
   invalidLookupAction: (missing) => `Updating a lookup requires that record, attribute, and value all be provided. Looks like ${missing.join("and")} is missing.`,
 
   neverEqual: (left, right) => `${left} can never equal ${right}`,

--- a/test/join.ts
+++ b/test/join.ts
@@ -1907,6 +1907,21 @@ test("pipe allows you to select ", (assert) => {
   assert.end();
 })
 
+test("blank lookup errors", (assert) => {
+  let expected = {
+    insert: [],
+    remove: [],
+    errors: true
+  };
+  evaluate(assert, expected, `
+    ~~~
+      search
+        lookup[]
+    ~~~
+  `);
+  assert.end();
+})
+
 test("lookup with bound record", (assert) => {
   let expected = {
     insert: [


### PR DESCRIPTION
Example
```
search
  lookup[]
```

Will produce error

```
Searching a lookup requires at least one of record, attribute, value, or node to be present
```

_(text may need a proofreading, since I'm not a native English speaker)_


I'll probably send another PR tomorrow to fix `lookup` to work with partially missing variables (related  https://github.com/witheve/Eve/pull/611#issuecomment-263498342).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/619)
<!-- Reviewable:end -->
