### PR TITLE
Wrap clients injectNotice calls to make it editor-agnostic

### DIFF
--- a/css/ide.css
+++ b/css/ide.css
@@ -82,9 +82,9 @@ body { justify-content: stretch; }
  * Notices
 \****************************************************************************/
 .main-pane { display: flex; flex-direction: column; justify-content: stretch; overflow-y: hidden; }
-.main-pane .notices { display: flex; flex: 0 0 auto; }
+.main-pane .notices { display: flex; flex: 0 0 auto; flex-direction: column; }
 
-.main-pane .notices > .notice { padding: 5px 60px; background: #e0e0e0; }
+.main-pane .notices > .notice { padding: 5px 60px; background: #e0e0e0; flex: 0 0 auto; }
 .main-pane .notices > .notice + .notice { border-bottom: 1px solid #d0d0d0; }
 .main-pane .notices > .notice > .time { margin-right: 10px;  }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -199,15 +199,23 @@ export class EveClient {
     this.send({type: "event", insert: eavs})
   }
 
+  injectNotice(type:string, message:string) {
+    if(this.ide) {
+      this.ide.injectNotice(type, message);
+    } else {
+      if(type === "error") console.error(message);
+      else if(type === "warning") console.warn(message);
+      else console.info(message);
+    }
+  }
+
   onError() {
     this.localControl = true;
     this.localEve = true;
     if(!this.ide) {
       this._initProgram({runtimeOwner: Owner.client, controlOwner: Owner.client, withIDE: true, path: (window.location.hash || "").slice(1) || "/examples/quickstart.eve"});
-    } else if(this.showIDE) {
-      this.ide.injectNotice("error", "Unexpectedly disconnected from the server. Please refresh the page.");
     } else {
-      console.error("Unexpectedly disconnected from the server. Please refresh the page.");
+      this.injectNotice("error", "Unexpectedly disconnected from the server. Please refresh the page.");
     }
   }
 
@@ -224,7 +232,7 @@ export class EveClient {
   }
 
   onClose() {
-    this.ide.injectNotice("warning", "The editor has lost connection to the Eve server. All changes will be made locally.");
+    this.injectNotice("warning", "The editor has lost connection to the Eve server. All changes will be made locally.");
   }
 
   onMessage(event) {
@@ -310,8 +318,7 @@ export class EveClient {
   }
 
   _error(data) {
-    if(!this.showIDE) return;
-    this.ide.injectNotice("error", data.message);
+    this.injectNotice("error", data.message);
   }
 
 }
@@ -472,7 +479,7 @@ function changeDocument() {
   try {
     ide.loadFile(docId);
   } catch(err) {
-    ide.injectNotice("info", "Unable to load unknown file: " + docId);
+    client.injectNotice("info", "Unable to load unknown file: " + docId);
   }
   ide.render();
 }

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2028,7 +2028,6 @@ export class IDE {
         {c: "message", text: notice.message}
       ]});
     }
-
     if(items.length) {
       return {c: "notices", children: items};
     }
@@ -2183,7 +2182,17 @@ export class IDE {
 
   injectNotice(type:string, message:string) {
     let time = Date.now();
-    this.notices.push({type, message, time});
+    let existing;
+    for(let notice of this.notices) {
+      if(notice.type === type && notice.message === message) {
+        existing = notice;
+        existing.time = time;
+        break;
+      }
+    }
+    if(!existing) {
+      this.notices.push({type, message, time});
+    }
     this.render();
     this.editor.cm.refresh();
   }


### PR DESCRIPTION
Reported by @convolvatron, not all calls to `ide.injectNotice` were guarded to ensure that we were running in editor mode. Rather than voiding those messages (as we were in other places) we now shunt them to the console. In the long term we should display them in-browser, but it's an open question as to how to do that without destroying the user-content below. Likely routes include an error modal or an overlay shade.