### PR TITLE
Increase MAX_ROUNDS 30 => 300

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -5,7 +5,7 @@
 import {PerformanceTracker, NoopPerformanceTracker} from "./performance";
 
 const TRACK_PERFORMANCE = true;
-const MAX_ROUNDS = 30;
+const MAX_ROUNDS = 300;
 
 //---------------------------------------------------------------------
 // Setups


### PR DESCRIPTION
This is necessary to make my Minesweeper example work for larger sizes. In the current version mine placement takes n*mines rounds to coalesce where n is some small factor n=1..3. I don't know if there's the possibility of a more principled or better approach for this longer term (eg maybe this could be configurable somehow and the default could be 30) but I think a larger value might be good to tide things over until this is decided on.