### PR TITLE
Fix Chevrotain Lexer Initialization.

### DIFF
--- a/src/runtime/parser.ts
+++ b/src/runtime/parser.ts
@@ -228,8 +228,8 @@ let LexerModes:any = {
 
 let allTokens: any[] = codeTokens.concat([Fence, DocContent, CloseString, StringEmbedOpen, StringEmbedClose, StringChars]);
 
-let EveDocLexer = new Lexer({modes: LexerModes, defaultMode: "doc"}, true);
-let EveBlockLexer = new Lexer({modes: LexerModes, defaultMode: "code"}, true);
+let EveDocLexer = new Lexer({modes: LexerModes, defaultMode: "doc"});
+let EveBlockLexer = new Lexer({modes: LexerModes, defaultMode: "code"});
 
 //-----------------------------------------------------------
 // Parse Nodes


### PR DESCRIPTION
The second argument (boolean) to the constructor of a Chevrotain Lexer
should not be used in most productive flows.

It effectivily disables the validations performed on the Lexer.
For example:
* Finding duplicate patterns.
* Using Lexer Modes which have not been defined.
* and more...

This boolean argument defers the handling of the errors instead of just throwing an error.
This incorrect usage must have been copied / pasted from an example in the Chevrotain online playground
(Where the defering is used to display errors in the UI).