### PR TITLE
quick fix for #586. A more durable solution is inbound

### DIFF
--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2130,6 +2130,14 @@ export class IDE {
 
     let md = this.editor.toMarkdown();
 
+    // @NOTE: We sync this here to prevent a terrible reload bug that occurs when saving to the file system.
+    // This isn't really the right fix, but it's a quick one that helps prevent lost work in trivial cases
+    // like navigating the workspace.
+    // @TODO: This logic needs ripped out entirely and replaced with a saner abstraction that keeps the
+    // file system and workspace in sync.
+    // @TODO: localStorage also needs to get synced and cleared lest it permanently overrule other sources of truth.
+    this._fileCache[this.documentId] = md;
+
     // if we're not local, we notify the outside world that we're trying
     // to save
     if(!this.local) {


### PR DESCRIPTION
When saving to the file system, localStorage is not updated. Unfortunately, since localStorage (and failing that, the fileCache) was used as the source of truth on the client, work would appear to be lost until a hard refresh, and would actually be lost if any edits were made prior to refreshing.

The fix here is fragile, and doesn't handle the case where the user has existing localStorage saves for the file or the case where the user edits in the editor, then the file system, then the editor again without a refresh in between, but it at least fixes the particular case in #586.

A more durable fix will arrive along with the client refactoring work.