### PR TITLE
fix todomvc comment: blur & enter commit, escape cancels

### DIFF
--- a/examples/todomvc.eve
+++ b/examples/todomvc.eve
@@ -127,9 +127,9 @@ Here we handle all the ways we edit a todo. Editing includes changing the body a
 
 - click `#todo-checkbox` - toggles the completed status of the checkbox.
 - click `#toggle-all` - marks all todos as complete or incomplete, depending on the initial value. If all todos are marked incomplete, clicking `#toggle-all` will mark them complete. If only some are marked complete, then clicking `#toggle-all` will mark the rest complete. If all todos are marked as complete, then clicking `#toggle-all` will mark them all as incomplete.
-- blur `#todo-editor` - blurring the `#todo-editor` will cancel the edit
-- escape `#todo-editor` - this has the same effect as blurring
+- escape `#todo-editor` - cancels the edit
 - enter `#todo-editor` - commits the new text in `#todo-editor`, replacing the original body
+- blur `#todo-editor` - has the same effect as enter
 
 ~~~
 search @event @session @browser


### PR DESCRIPTION
The comment is now consistent with both [todomvc spec][1] and the code (except for bug #607). Blur and enter should both commit the change, escape should cancel it.

[1]: https://github.com/tastejs/todomvc/blob/master/app-spec.md