### PR TITLE
implement aggregate join by overriding the whole aggregate() method.

### DIFF
--- a/examples/join.eve
+++ b/examples/join.eve
@@ -7,8 +7,10 @@
 ```
 
 ```
-   search [#foo name level]
+   search
+       [#foo name level]
        ordinal = sort[value:name given:name]
+
    commit @browser
        [#div text:join[value:name ordinal given:name separator:"/"]]
        [#div text:join[value:name ordinal:0 given:name separator:"/"]]

--- a/examples/join.eve
+++ b/examples/join.eve
@@ -1,0 +1,16 @@
+```
+  commit
+       [#foo name:"a" level:2]
+       [#foo name:"zkp" level:3]
+       [#foo name:"parg" level:0]
+       [#foo name:"naxxo" level:1]
+```
+
+```
+   search [#foo name level]
+       ordinal = sort[value:name given:name]
+   commit @browser
+       [#div text:join[value:name ordinal given:name separator:"/"]]
+       [#div text:join[value:name ordinal:0 given:name separator:"/"]]
+       [#div text:join[value:name ordinal:level given:name separator:"/"]]
+```

--- a/examples/join.eve
+++ b/examples/join.eve
@@ -1,18 +1,18 @@
 ```
   commit
-       [#foo name:"a" level:2]
-       [#foo name:"zkp" level:3]
-       [#foo name:"parg" level:0]
-       [#foo name:"naxxo" level:1]
+       [#foo token:"a" level:2]
+       [#foo token:"zkp" level:3]
+       [#foo token:"parg" level:0]
+       [#foo token:"naxxo" level:1]
 ```
 
 ```
    search
-       [#foo name level]
-       ordinal = sort[value:name given:name]
+       [#foo token level]
+       index = sort[value:token given:token]
 
    commit @browser
-       [#div text:join[value:name ordinal given:name separator:"/"]]
-       [#div text:join[value:name ordinal:0 given:name separator:"/"]]
-       [#div text:join[value:name ordinal:level given:name separator:"/"]]
+       [#div text:join[token index given:token with:"/"]]
+       [#div text:join[token index:0 given:token with:"/"]]
+       [#div text:join[token index:level given:token with:"/"]]
 ```

--- a/src/runtime/providers/aggregate.ts
+++ b/src/runtime/providers/aggregate.ts
@@ -181,17 +181,20 @@ export class Join extends Aggregate {
     "value": 0,
     "given": 1,
     "per": 2,
-    "ordinal": 3,
-    "separator": 4,
+    "index": 3,
+    "with": 4,
+    "token":0
   }
 
-  ordinal : any;
-  separator : any;
+  token : any;
+  index : any;
+  sepwith : any;
 
-  constructor(id: string, args: any[], returns: any[]) {
+constructor(id: string, args: any[], returns: any[]) {
     super(id, args, returns);
-    this.ordinal = args[3]
-    this.separator = args[4]
+    this.token = args[0]    
+    this.index = args[3]
+    this.sepwith = args[4]
   }
 
   aggregate(rows: any[]) {
@@ -202,11 +205,11 @@ export class Join extends Aggregate {
       resolve(this.groupVars, row, this.resolvedGroup)
       let group = this.resolvedAggregate.group;
       let projection = this.resolvedAggregate.projection;
-      let value = toValue(this.value, row);
-      let ordinal = toValue(this.ordinal, row);
-      let separator = toValue(this.separator, row);
+      let token = toValue(this.token, row);
+      let index = toValue(this.index, row);
+      let sepwith = toValue(this.sepwith, row);
 
-      if (separator === undefined) separator = "";
+      if (sepwith === undefined) sepwith = "";
 
       let groupKey = "[]";
       if(group.length !== 0) {
@@ -220,22 +223,22 @@ export class Join extends Aggregate {
       let projectionKey = JSON.stringify(projection);
       if(groupValues[projectionKey] === undefined) {
         groupValues[projectionKey] = true;
-        groupValues.result.push({value: value, ordinal:ordinal, separator:separator})
+        groupValues.result.push({token: token, index:index, sepwith:sepwith})
       }
     }
 
     for (let g in groups) {
         let s = groups[g].result.sort((a, b) => 
-                                      {if (a.ordinal > b.ordinal) return 1;
-                                       if (a.ordinal === b.ordinal) return 0;
+                                      {if (a.index > b.index) return 1;
+                                       if (a.index === b.index) return 0;
                                        return -1;})
         let len = s.length
         let result = ""
         for (var i=0; i<len; ++i) {
             // this means that the sep assocated with a value
             // is the one which occurs before the value
-            if (i != 0) result += s[i].separator
-            result += s[i].value 
+            if (i != 0) result += s[i].sepwith
+            result += s[i].token 
         }
         groups[g].result = result;
     }

--- a/src/runtime/providers/aggregate.ts
+++ b/src/runtime/providers/aggregate.ts
@@ -176,8 +176,79 @@ export class Max extends Aggregate {
   }
 }
 
+export class Join extends Aggregate {
+  static AttributeMapping = {
+    "value": 0,
+    "given": 1,
+    "per": 2,
+    "ordinal": 3,
+    "separator": 4,
+  }
+
+  ordinal : any;
+  separator : any;
+
+  constructor(id: string, args: any[], returns: any[]) {
+    super(id, args, returns);
+    this.ordinal = args[3]
+    this.separator = args[4]
+  }
+
+  aggregate(rows: any[]) {
+    let groupKeys = [];
+    let groups = {};
+    for(let row of rows) {
+      resolve(this.projectionVars, row, this.resolvedProjection)
+      resolve(this.groupVars, row, this.resolvedGroup)
+      let group = this.resolvedAggregate.group;
+      let projection = this.resolvedAggregate.projection;
+      let value = toValue(this.value, row);
+      let ordinal = toValue(this.ordinal, row);
+      let separator = toValue(this.separator, row);
+
+      if (separator === undefined) separator = "";
+
+      let groupKey = "[]";
+      if(group.length !== 0) {
+        groupKey = JSON.stringify(group);
+      }
+      let groupValues = groups[groupKey];
+      if(groupValues === undefined) {
+        groupKeys.push(groupKey);
+        groupValues = groups[groupKey] = {result:[]};
+      }
+      let projectionKey = JSON.stringify(projection);
+      if(groupValues[projectionKey] === undefined) {
+        groupValues[projectionKey] = true;
+        groupValues.result.push({value: value, ordinal:ordinal, separator:separator})
+      }
+    }
+
+    for (let g in groups) {
+        let s = groups[g].result.sort((a, b) => 
+                                      {if (a.ordinal > b.ordinal) return 1;
+                                       if (a.ordinal === b.ordinal) return 0;
+                                       return -1;})
+        let len = s.length
+        let result = ""
+        for (var i=0; i<len; ++i) {
+            // this means that the sep assocated with a value
+            // is the one which occurs before the value
+            if (i != 0) result += s[i].separator
+            result += s[i].value 
+        }
+        groups[g].result = result;
+    }
+    this.aggregateResults = groups;
+    return groups;
+  }
+  // unused but to keep mr. class happy
+  adjustAggregate(group, value, projection) {}
+}
+
 providers.provide("sum", Sum);
 providers.provide("count", Count);
 providers.provide("average", Average);
+providers.provide("join", Join);
 providers.provide("min", Min);
 providers.provide("max", Max);

--- a/test/all.ts
+++ b/test/all.ts
@@ -1,3 +1,4 @@
 import "./join";
 import "./eavs";
 import "./math";
+import "./strings";

--- a/test/shared_functions.ts
+++ b/test/shared_functions.ts
@@ -187,6 +187,28 @@ export function evaluate(assert, expected, code, session = new Database()) {
   return next;
 }
 
+export function evaluates(assert, code, session = new Database()) {
+  let parsed = parser.parseDoc(dedent(code), "0");
+  let {blocks, errors} = builder.buildDoc(parsed.results);
+  session.blocks = session.blocks.concat(blocks);
+  let evaluation = new Evaluation();
+  evaluation.registerDatabase("session", session);
+  let changes = evaluation.fixpoint();
+
+  var success = false
+  var inserts = changes.result().insert
+  for(let triple of inserts) {
+    console.log("ko", triple[1], triple[2])
+    if ((triple[1] === "tag") && (triple[2] === "success")) 
+      success = true;
+  }
+  if (success) {
+    assert.true(true, "test complete");
+  }  else {
+    assert.true(false, "test failed");
+  }
+}
+
 export interface valueTest {
   expression: string;
   expectedValue: number;

--- a/test/shared_functions.ts
+++ b/test/shared_functions.ts
@@ -198,7 +198,6 @@ export function evaluates(assert, code, session = new Database()) {
   var success = false
   var inserts = changes.result().insert
   for(let triple of inserts) {
-    console.log("ko", triple[1], triple[2])
     if ((triple[1] === "tag") && (triple[2] === "success")) 
       success = true;
   }

--- a/test/strings.ts
+++ b/test/strings.ts
@@ -1,0 +1,27 @@
+import * as test from "tape";
+import {evaluates} from "./shared_functions";
+
+test("test string join ordering", (assert) => {
+  evaluates(assert, `
+               ~~~
+                 commit
+                      [#foo token:"a" level:2]
+                      [#foo token:"zkp" level:3]
+                      [#foo token:"parg" level:0]
+                      [#foo token:"naxxo" level:1]
+               ~~~
+
+                ~~~
+                search
+                  [#foo token level]
+                  index = sort[value:token given:token]                 
+                  a = join[token index given:token with:"/"]
+                  a = "a/naxxo/parg/zkp"
+                  b = join[token index:level given:token with:"/"]
+                  b = "parg/naxxo/a/zkp"                  
+                commit
+                  [#success]
+                ~~~
+  `);
+  assert.end();
+});


### PR DESCRIPTION
This version allows for separator to be a set, but doesn't put a separator at the beginning or end of the result string