### PR TITLE
Fix a bug in "gaussian" function

### DIFF
--- a/src/runtime/providers/math.ts
+++ b/src/runtime/providers/math.ts
@@ -310,12 +310,12 @@ class Gaussian extends TotalFunctionConstraint {
     let [seed, sigma, mu] = args;
     if (sigma === undefined) sigma = 1.0
     if (mu === undefined) mu = 0.0
-    let found = Gaussian.cache[seed];
+    let key =  "" + seed + sigma + mu
+    let found = Gaussian.cache[key];
     if(found) return found;
     let u1 = Math.random()
     let u2 = Math.random()
     let z0 = Math.sqrt(-2.0 * Math.log(u1) ) * Math.cos (Math.PI * 2 * u2)
-    let key =  "" + seed + sigma + mu
     let res =  z0 * sigma + mu;
     Gaussian.cache[key] = res
     return res

--- a/test/math.ts
+++ b/test/math.ts
@@ -318,3 +318,55 @@ test("ATanH < -1 and > 1 should return nothing.", (assert) => {
   `);
   assert.end();
 });
+
+test("Test random seed", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "same-seed", "true"],
+      ["b", "different-seed", "false"],
+    ],
+    remove: [],
+  };
+
+  evaluate(assert, expected, `
+    ~~~
+    search
+      r1 = random[seed:0]
+      r2 = random[seed:0]
+      r3 = random[seed:1]
+      same-seed = if r1 = r2 then "true" else "false"
+      different-seed = if r1 = r3 then "true" else "false"
+
+    bind
+      [same-seed]
+      [different-seed]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("Test gaussian seed", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "same-seed", "true"],
+      ["b", "different-seed", "false"],
+    ],
+    remove: [],
+  };
+
+  evaluate(assert, expected, `
+    ~~~
+    search
+      g1 = gaussian[seed:0, σ:1.0, µ:0.0]
+      g2 = gaussian[seed:0, σ:1.0, µ:0.0]
+      g3 = gaussian[seed:1, σ:1.0, µ:0.0]
+      same-seed = if g1 = g2 then "true" else "false"
+      different-seed = if g1 = g3 then "true" else "false"
+
+    bind
+      [same-seed]
+      [different-seed]
+    ~~~
+  `);
+  assert.end();
+})


### PR DESCRIPTION
The Gaussian provider uses different keys when reading and writing into the internal cache, so it violates referential transparency as describe here: https://gist.github.com/joshuafcole/52f706e0e838b3fb7536814de8879af0.