### PR TITLE
fix sort.test() not correctly looking up results

### DIFF
--- a/src/runtime/providers/sort.ts
+++ b/src/runtime/providers/sort.ts
@@ -98,11 +98,11 @@ export class Sort extends Constraint {
   }
 
   test(prefix) {
-    let {group} = this.resolveAggregate(prefix);
+    let {group, value} = this.resolveAggregate(prefix);
     let resultGroup = this.aggregateResults[JSON.stringify(group)];
     if(resultGroup !== undefined) {
       let returns = resolve(this.returns, prefix, this.resolvedReturns);
-      return returns[0] === resultGroup.result;
+      return returns[0] === resultGroup[JSON.stringify(value)];
     }
   }
 


### PR DESCRIPTION
This was a copy-pasta mistake when porting sort from other aggregates. Unlike a normal aggregate which only needs to lookup the result based on group, each value in the group of a sort has an index that needs to be looked up.

This fixes [this issue](https://groups.google.com/forum/#!topic/eve-talk/stC-znRyUQE) reported on the mailing list.