### PR TITLE
When user types tab, translate it into spaces for consistency

### DIFF
--- a/src/ide.ts
+++ b/src/ide.ts
@@ -657,7 +657,15 @@ export class Editor {
       "Cmd-1": () => this.format({type: "heading", level: 1}),
       "Cmd-2": () => this.format({type: "heading", level: 2}),
       "Cmd-3": () => this.format({type: "heading", level: 3}),
-      "Cmd-L": () => this.format({type: "item"})
+      "Cmd-L": () => this.format({type: "item"}),
+      "Tab": (cm) => {
+        if (cm.somethingSelected()) {
+          cm.indentSelection("add");
+        } else {
+          cm.replaceSelection(cm.getOption("indentWithTabs")? "\t":
+          Array(cm.getOption("indentUnit") + 1).join(" "), "end", "+input");
+        }
+      }
     })
   };
 


### PR DESCRIPTION
Hello, you wonderful Eve people!

As I started working on my first Eve project, I noticed something odd. Code blocks that looked fine in the browser IDE were saved to disk with odd indentation inconsistencies. [Here's an example](https://github.com/asolove/Eve/pull/3/files#diff-0a7fde0cf8bef01cdfe0772e72e41d2bR47): 

![screen shot 2016-12-06 at 10 40 44 am](https://cloud.githubusercontent.com/assets/8495/20936716/d8634e2c-bba0-11e6-884c-37d1ca3a6108.png)

It turns out that when the editor automatically indents inside code blocks, it adds a soft tab of two spaces. But when the user hits the tab key, CodeMirror was adding a literal tab and displaying it with a width of two spaces. So when the code is saved to disk, some lines are indented two spaces (if they came from auto-indent) and some were indented with tabs (because I indented them)

Luckily there's a [length conversation about soft tabs](https://github.com/codemirror/CodeMirror/issues/988) over in the CodeMirror issues and it had a pretty simple solution. I've ported that straight over here and assumed it should just live as a CodeMirror hack in those key options rather than getting into the `Editor` level. If you want this actually in `Editor`, it looks like we'd have to add some more typings to expose the CM methods this uses.

Thanks for Eve! Hope this is helpful.