### PR TITLE
Fix stratification when joining aggregate results with other scans

### DIFF
--- a/src/runtime/builder.ts
+++ b/src/runtime/builder.ts
@@ -668,7 +668,9 @@ function stratify(scans) {
             infoLevel = info.level
           }
           // if this is an aggregate, we always have to be in the level that is
-          // one greater than all our dependencies
+          // one greater than all our dependencies.
+          // In the event that one of our dependencies is filtered by an aggregate,
+          // we stratify ourselves behind it.
           if(isAgg) {
             for(let provider of info.providers) {
               if(isAggregate(provider) && provider !== scan) {

--- a/test/join.ts
+++ b/test/join.ts
@@ -1063,6 +1063,75 @@ test("aggregate stratification with results", (assert) => {
   assert.end();
 });
 
+test("aggregate stratification result joined with an object", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "tag", "person"],
+      ["a", "name", "joe"],
+      ["b", "tag", "person"],
+      ["b", "name", "chris"],
+      ["c", "tag", "expected"],
+      ["c", "total", 2],
+      ["d", "tag", "success"],
+    ],
+    remove: [
+    ]
+  };
+  evaluate(assert, expected, `
+    people
+    ~~~
+      commit
+        [#expected total: 2]
+        [#person name: "joe"]
+        [#person name: "chris"]
+    ~~~
+
+    ~~~
+      search
+        expected = [#expected]
+        p = [#person]
+        expected.total = count[given: p]
+      commit
+        [#success]
+    ~~~
+  `);
+  assert.end();
+});
+
+test("aggregate stratification result fails to join with an object", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "tag", "person"],
+      ["a", "name", "joe"],
+      ["b", "tag", "person"],
+      ["b", "name", "chris"],
+      ["c", "tag", "expected"],
+      ["c", "total", 3],
+    ],
+    remove: [
+    ]
+  };
+  evaluate(assert, expected, `
+    people
+    ~~~
+      commit
+        [#expected total: 3]
+        [#person name: "joe"]
+        [#person name: "chris"]
+    ~~~
+
+    ~~~
+      search
+        expected = [#expected]
+        p = [#person]
+        expected.total = count[given: p]
+      commit
+        [#success]
+    ~~~
+  `);
+  assert.end();
+});
+
 test("aggregate stratification with another aggregate", (assert) => {
   let expected = {
     insert: [
@@ -1118,7 +1187,7 @@ test("unstratifiable aggregate", (assert) => {
           [#person name: "mike" age: 20]
       ~~~
 
- 
+
       ~~~
         search
           p = [#person age]

--- a/test/join.ts
+++ b/test/join.ts
@@ -2764,3 +2764,45 @@ test("nested if/not expressions correctly get their args set", (assert) => {
   `);
   assert.end();
 })
+
+test("interdependent aggregates are appropriately stratified", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "tag", "foo"],
+      ["a", "a", 3],
+      ["a", "a", 5],
+
+      ["b", "tag", "bar"],
+      ["b", "b", 1],
+      ["b", "b", 2],
+      ["b", "b", 3],
+
+      ["c", "tag", "result"],
+      ["c", "value", 3]
+    ],
+    remove: [],
+  };
+  evaluate(assert, expected, `
+    Add some test data
+    ~~~ eve
+    commit
+      [#foo a: (3, 5)]
+      [#bar b: (1, 2, 3)]
+    ~~~
+
+
+    ~~~ eve
+    search
+      [#foo a]
+      [#bar b]
+
+      a = count[given: b]
+      final = sum[value: a, given: a]
+
+    bind
+      [#result value: final]
+    ~~~
+
+  `);
+  assert.end();
+})


### PR DESCRIPTION
The issue in #649 was caused by a set of issues. First, the maybeLevel function had bugs in it that caused us to look at the wrong scan to determine the minimum level for a variable. Second, we were automatically setting the returns of an aggregate to the same level as the aggregate itself, which is incorrect in the case where there are other providers for a variable (e.g. a database scan).

To fix this, I fixed the bugs in maybeLevel and then instead of blanket setting all returns of aggs to the aggs' level, I do a pass to check for the minimum level that could provide that var and set it to that.

Fixes #649.