### PR TITLE
Fix DependencyChecker if branch that looks at attributes with a fixed value

### DIFF
--- a/src/runtime/block.ts
+++ b/src/runtime/block.ts
@@ -120,7 +120,7 @@ export class DependencyChecker {
     if(deps["any"]) {
       let attr = deps["any"][a];
       if(attr === true) return true;
-      if(attr === true && attr[v] === true) return true
+      if(attr && attr[v] === true) return true
     }
     for(let tag of tags) {
       let attrIndex = deps[tag];


### PR DESCRIPTION
Very strange symptoms are caused by this mistake which would prevent some blocks from running even when changes should've made them do so. Any block that looked for an attribute with a fixed value on a record with no tags would be skipped since `attr` cannot be both `true` and an object at the same time :(