### PR TITLE
Make sure records in parenthesis are treated the same

### DIFF
--- a/src/runtime/parser.ts
+++ b/src/runtime/parser.ts
@@ -899,7 +899,7 @@ export class Parser extends chev.Parser {
                 } else if(parent) {
                   record.extraProjection.push(parent);
                 }
-                // Lastly we need add the eve-auto-index attribute to make sure this is consistent with the case
+                // Lastly we need to add the eve-auto-index attribute to make sure this is consistent with the case
                 // where we leave the parenthesis off and just put records one after another.
                 record.attributes.push(makeNode("attribute", {attribute: "eve-auto-index", value: makeNode("constant", {value: autoIndex, from: [record]}), from: [record]}));
                 autoIndex++;

--- a/src/runtime/parser.ts
+++ b/src/runtime/parser.ts
@@ -887,7 +887,6 @@ export class Parser extends chev.Parser {
           // down to them. If we don't do this, we'll end up with children that are shared between
           // the parents instead of one child per parent.
           if(result.type === "parenthesis") {
-          console.log("HERE")
             for(let item of result.items) {
               // this is a bit sad, but by the time we see the parenthesis, the records have been replaced
               // with their variables. Those variables are created from the record object though, so we can

--- a/test/join.ts
+++ b/test/join.ts
@@ -191,6 +191,63 @@ test("search with attribute having multiple values in parenthesis with a functio
   assert.end();
 })
 
+test.only("sub-records in a parenthesis pick up their parent as part of their identity", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "tag", "person"],
+      ["a", "name", "chris"],
+      ["a", "age", 20],
+
+      ["b", "tag", "person"],
+      ["b", "name", "joe"],
+      ["b", "age", 20],
+
+      ["c", "tag", "div"],
+      ["c", "p", "a"],
+      ["c", "children", "d"],
+      ["c", "children", "e"],
+
+      ["d", "tag", "div"],
+      ["d", "text", "age"],
+      ["d", "eve-auto-index", 1],
+
+      ["e", "tag", "div"],
+      ["e", "text", 20],
+      ["e", "eve-auto-index", 2],
+
+      ["f", "tag", "div"],
+      ["f", "p", "b"],
+      ["f", "children", "g"],
+      ["f", "children", "h"],
+
+      ["g", "tag", "div"],
+      ["g", "text", "age"],
+      ["g", "eve-auto-index", 1],
+
+      ["h", "tag", "div"],
+      ["h", "text", 20],
+      ["h", "eve-auto-index", 2],
+    ],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    people
+    ~~~
+      commit
+        [#person name: "chris" age: 20]
+        [#person name: "joe" age: 20]
+    ~~~
+
+    ~~~
+      search
+        p = [#person name age]
+      commit
+           [#div p children: ([#div text: "age"], [#div text: age])]
+    ~~~
+  `);
+  assert.end();
+})
+
 test("create a record with numeric attributes", (assert) => {
   let expected = {
     insert: [


### PR DESCRIPTION
In code where sub-records were defined in a parenthesis, we weren't pushing the parent's identity down into the children, we also weren't setting `eve-auto-index` on them. This makes sure we do both and should remove any differences between using parens or not.

Fixes. #673 