### PR TITLE
Feature/save load gist

### DIFF
--- a/assets/css/ide.css
+++ b/assets/css/ide.css
@@ -35,8 +35,7 @@ body { justify-content: stretch; }
 /****************************************************************************\
  * Navigator
 \****************************************************************************/
-.navigator-header { display: flex; flex-direction: column; padding:10px 5px; user-select: none; -webkit-user-select: none; margin-bottom:10px; font-size:18px; color: #555; transition:color 0.2s ease-in-out; }
-.navigator-pane:hover .navigator-header { color: #aaa;  }
+.navigator-header { display: flex; flex-direction: column; padding:10px 5px; user-select: none; -webkit-user-select: none; margin-bottom:10px; font-size:18px; color: #aaa; transition:color 0.2s ease-in-out; }
 .navigator-header > .controls { display:flex; flex-direction:row; flex:1; }
 .navigator-header > .controls > * {height: 20px; text-align: center; padding: 0 5px; transition: transform 0.3s; cursor: pointer; }
 .navigator-header > .controls > *:last-child { margin-right: -5px; }

--- a/assets/css/ide.css
+++ b/assets/css/ide.css
@@ -82,11 +82,15 @@ body { justify-content: stretch; }
  * Notices
 \****************************************************************************/
 .main-pane { display: flex; flex-direction: column; justify-content: stretch; overflow-y: hidden; }
-.main-pane .notices { display: flex; flex: 0 0 auto; flex-direction: column; }
+.main-pane .notices { display: flex; flex: 0 0 auto; flex-direction: column; border-right: 1px solid #ddd; border-bottom: 1px solid #ddd; }
 
-.main-pane .notices > .notice { padding: 5px 60px; background: #e0e0e0; flex: 0 0 auto; }
-.main-pane .notices > .notice + .notice { border-bottom: 1px solid #d0d0d0; }
+.main-pane .notices > .notice { padding: 5px 60px; background: #f5f5f5; flex: 0 0 auto; }
+.main-pane .notices > .notice + .notice { border-top: 1px solid #ddd; }
 .main-pane .notices > .notice > .time { margin-right: 10px;  }
+
+.main-pane .notices > .notice > .dismiss-btn { margin-left: 10px; vertical-align: bottom; align-self: center; opacity: 0; transition: opacity 0.2s; }
+.main-pane .notices:hover > .notice > .dismiss-btn { opacity: 1; }
+.main-pane .notices > .notice > .dismiss-btn:hover { background: #eee; }
 
 .main-pane .notices > .notice.error { background: rgb(255, 216, 222); }
 .main-pane .notices > .notice.warning { background: rgb(255, 247, 217); }

--- a/assets/css/ide.css
+++ b/assets/css/ide.css
@@ -44,6 +44,13 @@ body { justify-content: stretch; }
 .navigator-header .collapse-btn { transform: rotate(180deg); color: #999; }
 .navigator-header .up-btn.disabled > .up-icon { opacity: 0; }
 
+.navigator-pane .load-dialog { padding: 10 25; color: #555; margin-top: -10px; margin-bottom: 10px; }
+.navigator-pane .load-dialog input { padding: 5px; outline: none; border-top-left-radius: 2px; border: 1px solid #CCC; border-bottom-left-radius: 2px; }
+.navigator-pane .load-dialog .load-btn { padding: 5px; background: white; border: 1px solid #CCC; border-left-color: transparent; border-top-right-radius: 2px; border-bottom-right-radius: 2px; }
+.navigator-pane .load-dialog .load-btn:before { position: relative; top: 3px; }
+.navigator-pane .load-dialog .load-btn:hover { background: #EEE; }
+.navigator-pane .load-dialog .load-btn:active { background: #DDD; }
+
 .navigator-header .up-btn .label { display: flex; font-size:16px; margin-left: 10px; }
 .navigator-header .label { white-space: pre; display:none; }
 

--- a/assets/css/ide.css
+++ b/assets/css/ide.css
@@ -38,7 +38,8 @@ body { justify-content: stretch; }
 .navigator-header { display: flex; flex-direction: column; padding:10px 5px; user-select: none; -webkit-user-select: none; margin-bottom:10px; font-size:18px; color: #555; transition:color 0.2s ease-in-out; }
 .navigator-pane:hover .navigator-header { color: #aaa;  }
 .navigator-header > .controls { display:flex; flex-direction:row; flex:1; }
-.navigator-header > .controls > * { height: 20px; padding-left: 10px; text-align: center; transition: transform 0.3s; cursor: pointer; }
+.navigator-header > .controls > * {height: 20px; text-align: center; padding: 0 5px; transition: transform 0.3s; cursor: pointer; }
+.navigator-header > .controls > *:last-child { margin-right: -5px; }
 .navigator-header > .controls > div:not(.disabled):hover { color: #eee; }
 .navigator-pane.collapsed:hover .navigator-header > .controls > div { color: #eee; }
 .navigator-header .collapse-btn { transform: rotate(180deg); color: #999; }

--- a/assets/css/ide.css
+++ b/assets/css/ide.css
@@ -38,12 +38,12 @@ body { justify-content: stretch; }
 .navigator-header { display: flex; flex-direction: column; padding:10px 5px; user-select: none; -webkit-user-select: none; margin-bottom:10px; font-size:18px; color: #555; transition:color 0.2s ease-in-out; }
 .navigator-pane:hover .navigator-header { color: #aaa;  }
 .navigator-header > .controls { display:flex; flex-direction:row; flex:1; }
-.navigator-header > .controls > * { height: 20px; text-align: center; transition: transform 0.3s; cursor: pointer; }
-.navigator-header > .controls > div:hover { color: #eee; }
+.navigator-header > .controls > * { height: 20px; padding-left: 10px; text-align: center; transition: transform 0.3s; cursor: pointer; }
+.navigator-header > .controls > div:not(.disabled):hover { color: #eee; }
 .navigator-pane.collapsed:hover .navigator-header > .controls > div { color: #eee; }
-.navigator-header:hover > .controls > *:not(.disabled) {  }
 .navigator-header .collapse-btn { transform: rotate(180deg); color: #999; }
-.navigator-header .btn { padding: 0 5px; }
+.navigator-header .up-btn.disabled > .up-icon { opacity: 0; }
+
 .navigator-header .up-btn .label { display: flex; font-size:16px; margin-left: 10px; }
 .navigator-header .label { white-space: pre; display:none; }
 

--- a/assets/css/ide.css
+++ b/assets/css/ide.css
@@ -89,7 +89,7 @@ body { justify-content: stretch; }
 /****************************************************************************\
  * Notices
 \****************************************************************************/
-.main-pane { display: flex; flex-direction: column; justify-content: stretch; overflow-y: hidden; }
+.main-pane { display: flex; flex-direction: column; justify-content: stretch; overflow-y: hidden; position: relative; }
 .main-pane .notices { display: flex; flex: 0 0 auto; flex-direction: column; border-right: 1px solid #ddd; border-bottom: 1px solid #ddd; }
 
 .main-pane .notices > .notice { padding: 5px 60px; background: #f5f5f5; flex: 0 0 auto; }
@@ -102,6 +102,21 @@ body { justify-content: stretch; }
 
 .main-pane .notices > .notice.error { background: rgb(255, 216, 222); }
 .main-pane .notices > .notice.warning { background: rgb(255, 247, 217); }
+
+/****************************************************************************\
+ * Modals
+\****************************************************************************/
+.main-pane > .modal-overlay {display: flex;justify-content: center;align-items: center;position: absolute;top: 0;left: 0;bottom: 0;right: 0;z-index: 5;background: rgba(0, 0, 0, 0.1);}
+.main-pane > .modal-overlay .modal-window { display: flex; flex-direction: column; width: 320; padding: 20; background: #FFF; border-radius: 4px; z-index: 10; box-shadow: 0 4px 5px rgba(0, 0, 0, 0.25); }
+.main-pane > .modal-overlay .modal-window h3 { align-self: center; margin-top: 0; }
+.main-pane > .modal-overlay .modal-window .controls { flex: 0 0 auto; }
+.main-pane > .modal-overlay .modal-window .btn { flex: 1; text-align: center; padding: 5 10; border: 1px solid #DDD; border-radius: 4px; -webkit-user-select: none; -moz-webkit-user-select: none; }
+.main-pane > .modal-overlay .modal-window .btn + .btn { margin-left: 10; }
+.main-pane > .modal-overlay .modal-window .btn:hover { background: #EEE; }
+.main-pane > .modal-overlay .modal-window .btn:active {background: #DDD; }
+.main-pane > .modal-overlay .modal-window .btn.danger { background: #EE5555; color: white; border: #CC3333; }
+.main-pane > .modal-overlay .modal-window .btn.danger:hover { background: #DD4444; }
+.main-pane > .modal-overlay .modal-window .btn.danger:active { background: #CC3333; }
 
 /****************************************************************************\
  * Editor

--- a/assets/css/ide.css
+++ b/assets/css/ide.css
@@ -43,6 +43,7 @@ body { justify-content: stretch; }
 .navigator-pane.collapsed:hover .navigator-header > .controls > div { color: #eee; }
 .navigator-header:hover > .controls > *:not(.disabled) {  }
 .navigator-header .collapse-btn { transform: rotate(180deg); color: #999; }
+.navigator-header .btn { padding: 0 5px; }
 .navigator-header .up-btn .label { display: flex; font-size:16px; margin-left: 10px; }
 .navigator-header .label { white-space: pre; display:none; }
 

--- a/examples/todomvc.eve
+++ b/examples/todomvc.eve
@@ -52,11 +52,11 @@ bind @browser
             [#strong text: todo-count]
         [#span text: " items left"]]
         [#ul #filters, class: "filters", children:
-        [#li children: [#a href: "#/examples/todomvc.eve/#/all" text: "all"
+        [#li children: [#a href: "#/all" text: "all"
                                              class: [selected: is(filter = "all")]]]
-        [#li children: [#a href: "#/examples/todomvc.eve/#/active" text: "active"
+        [#li children: [#a href: "#/active" text: "active"
                                              class: [selected: is(filter = "active")]]]
-        [#li children: [#a href: "#/examples/todomvc.eve/#/completed" text: "completed"
+        [#li children: [#a href: "#/completed" text: "completed"
                                              class: [selected: is(filter = "completed")]]]]
             [#span #clear-completed text: "Clear completed"
                                                         class: [clear-completed: true,

--- a/src/client.ts
+++ b/src/client.ts
@@ -471,6 +471,7 @@ function changeDocument() {
   // @FIXME: This is not right in the non-internal case.
   let docId = "/examples/quickstart.eve";
   let path = location.hash && location.hash.split('?')[0].split("#")[1];
+  if(path[path.length - 1] === "/") path = path.slice(0, -1);
   if(path && path.length > 2) {
     if(path[path.length - 1] === "/") path = path.slice(0, -1);
     docId = path;

--- a/src/client.ts
+++ b/src/client.ts
@@ -287,6 +287,7 @@ export class EveClient {
       // Ensure the URL bar is in sync with the server.
       // @FIXME: This back and forth of control over where we are
       // is an Escherian nightmare.
+
       if(!data.path) {
         history.pushState({}, "", window.location.pathname);
       }
@@ -469,11 +470,12 @@ function changeDocument() {
   let ide = client.ide;
   // @FIXME: This is not right in the non-internal case.
   let docId = "/examples/quickstart.eve";
-  let path = location.hash && location.hash.split('?')[0].split("#/")[1];
+  let path = location.hash && location.hash.split('?')[0].split("#")[1];
   if(path && path.length > 2) {
     if(path[path.length - 1] === "/") path = path.slice(0, -1);
-    docId = "/" + path;
+    docId = path;
   }
+
   if(!docId) return;
   if(docId === ide.documentId) return;
   try {

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -94,8 +94,10 @@ class Navigator {
 
     let root:TreeNode = this.nodes[id];
     if(!root) {
-      console.error("Cannot load non-existent document.");
-      return;
+      //console.error("Cannot load non-existent document.");
+      //return;
+
+      root = this.nodes[id] = {id, type: "document", name};
     }
     root.open = true;
     root.children = undefined;
@@ -407,8 +409,8 @@ class Navigator {
     let type = this.currentType();
     return {c: "navigator-header", children: [
       {c: "controls", children: [
-        this.open ? {c: `up-btn flex-row`, click: this.navigate, children: [
-          type === "document" ? {c:  `up-btn ion-android-arrow-up ${(type === "folder") ? "disabled" : ""}`} : undefined,
+        this.open ? {c: `up-btn flex-row  ${(this.currentId === this.rootId) ? "disabled" : ""}`, click: this.navigate, children: [
+          {c:  "up-icon ion-android-arrow-up"},
           {c: "label", text: "examples"}
         ]} : undefined,
         {c: "flex-spacer"},
@@ -2228,7 +2230,7 @@ export class IDE {
       this.injectNotice("warning", "Unable to open gist: No URL provided.");
       return;
     }
-    readFromGist(url, (err, content) => {
+    readFromGist(url, (err, gist) => {
       if(err) {
         this.injectNotice("error", "Unable to read gist. Check the developer console for more information.");
         console.error(err);
@@ -2236,7 +2238,11 @@ export class IDE {
         //console.log(content);
         // @FIXME: Need the filename metadata here.
         // @FIXME: Should really be more flexible and provide all the files attached (can load a workspace from gist).
-        this.loadFile("Gist", content);
+        for(let filename in gist.files) {
+          let content = gist.files[filename].content;
+          let docId = `gist:${gist.id}-${filename}`;
+          this.loadFile(docId, content);
+        }
       }
     });
   }

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2120,7 +2120,8 @@ export class IDE {
       let gistId = docId.slice(5);
       if(gistId.indexOf("-") !== -1) gistId = gistId.slice(0, gistId.indexOf("-"));
       let gistUrl = `https://gist.githubusercontent.com/raw/${gistId}`;
-      return this.loadFromGist(gistUrl);
+      this.loadFromGist(gistUrl);
+      return true;
     }
 
     // if we're not in local mode, file content is going to come from

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -332,7 +332,15 @@ class Navigator {
     this.loadDialogValue = input.value;
   }
 
-  loadFromDialog = () => {
+  loadFromDialog = (event) => {
+    if(event instanceof KeyboardEvent) {
+      if(event.keyCode === 27) { // Escape
+        this.loadDialogValue = undefined;
+        this.loadDialogOpen = false;
+        this.ide.render();
+      }
+      if(event.keyCode !== 13) return; // Enter
+    }
     this.ide.loadFromGist(this.loadDialogValue);
     this.loadDialogValue = undefined;
     this.loadDialogOpen = false;
@@ -426,7 +434,7 @@ class Navigator {
 
   loadDialog():Elem {
     return {c: "load-dialog flex-row", children: [
-      {t: "input", c: "flex-spacer", type: "url", placeholder: "Enter gist url...", input: this.loadDialogInput},
+      {t: "input", c: "flex-spacer", type: "url", autofocus: true, placeholder: "Enter gist url...", input: this.loadDialogInput, keydown: this.loadFromDialog},
       {c: "btn load-btn ion-arrow-right-b", style: "padding: 0 10", click: this.loadFromDialog}
     ]};
   }
@@ -2106,6 +2114,15 @@ export class IDE {
 
   loadFile(docId:string, content?:string) {
     if(!docId) return false;
+
+    // We're loading from a remote gist
+    if(docId.indexOf("gist:") === 0 && !content) {
+      let gistId = docId.slice(5);
+      if(gistId.indexOf("-")) gistId = gistId.slice(0, gistId.indexOf("-"));
+      let gistUrl = `https://gist.githubusercontent.com/raw/${gistId}`;
+      return this.loadFromGist(gistUrl);
+    }
+
     // if we're not in local mode, file content is going to come from
     // some other source and we should just load it directly
     if(!this.local && content !== undefined) {

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2324,6 +2324,7 @@ export class IDE {
     location.hash = modified;
 
     this.saveDocument();
+    this.navigator.loadDocument(neueId, neueId);
   }
 
   saveToGist() {

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -1723,7 +1723,7 @@ export class Editor {
 
     return {c: "flex-row controls", children: [
       {c: "ion-ios-cloud-upload-outline", title: "Save to Gist", click: () => this.ide.saveToGist()},
-      {c: "ion-ios-cloud-download-outline", title: "Load from Gist", click: () => this.ide.loadFromGist()},
+      {c: "ion-ios-cloud-download-outline", title: "Load from Gist", click: () => this.ide.loadFromGist(undefined)}, // @FIXME
       {c: "ion-refresh", title: "Reset (⌃⇧⏎ or ⇧⌘⏎ )", click: () => this.ide.eval(false)},
       {c: "ion-ios-play", title: "Run (⌃⏎ or ⌘⏎)", click: () => this.ide.eval(true)},
       inspectorButton
@@ -2077,9 +2077,11 @@ export class IDE {
     // some other source and we should just load it directly
     if(!this.local && content !== undefined) {
       this.documentId = docId;
+      this._fileCache[docId] = content;
       this.editor.reset();
       this.notices = [];
       this.loading = true;
+      this.loaded = false;
       this.onLoadFile(this, docId, content);
       return true;
     } else if(this.loading || this.documentId === docId) {
@@ -2185,15 +2187,28 @@ export class IDE {
         this.injectNotice("error", "Unable to save file to gist. Check the developer console for more information.");
         console.error(err);
       } else {
-        // @FIXME: This needs to be an anchor tag.
-        // @FIXME: info notices need to be dismissible.
         this.injectNotice("info", () => ({c: "flex-row", children: [{text: "Saved to", style: "padding-right: 5px;"}, {t: "a", href: url, target: "_blank", text: "gist"}]}));
       }
     });
   }
 
-  loadFromGist() {
-    console.error("@TODO: Implement me!");
+  loadFromGist(url:string) {
+    if(!url) {
+      console.error("@TODO: Implement me!", this);
+      return;
+    }
+
+    readFromGist(url, (err, content) => {
+      if(err) {
+        this.injectNotice("error", "Unable to read gist. Check the developer console for more information.");
+        console.error(err);
+      } else {
+        //console.log(content);
+        // @FIXME: Need the filename metadata here.
+        // @FIXME: Should really be more flexible and provide all the files attached (can load a workspace from gist).
+        this.loadFile("Gist", content);
+      }
+    });
   }
 
   createDocument(folder:string) {

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -1,7 +1,7 @@
 import {Renderer, Element as Elem, RenderHandler} from "microReact";
 import {Parser as MDParser} from "commonmark";
 import * as CodeMirror from "codemirror";
-import {debounce, uuid, unpad, Range, Position, isRange, compareRanges, comparePositions, samePosition, whollyEnclosed, adjustToWordBoundary} from "./util";
+import {debounce, uuid, unpad, Range, Position, isRange, compareRanges, comparePositions, samePosition, whollyEnclosed, adjustToWordBoundary, writeToGist, readFromGist} from "./util";
 
 import {Span, SpanMarker, isSpanMarker, isEditorControlled, spanTypes, compareSpans, SpanChange, isSpanChange, HeadingSpan, CodeBlockSpan, DocumentCommentSpan} from "./ide/spans";
 import * as Spans from "./ide/spans";
@@ -1714,6 +1714,8 @@ export class Editor {
     else if(this.ide.inspecting) inspectorButton.c += " inspecting";
 
     return {c: "flex-row controls", children: [
+      {c: "ion-ios-cloud-upload-outline", title: "Save to Gist", click: () => this.ide.saveToGist()},
+      {c: "ion-ios-cloud-download-outline", title: "Load from Gist", click: () => this.ide.loadFromGist()},
       {c: "ion-refresh", title: "Reset (⌃⇧⏎ or ⇧⌘⏎ )", click: () => this.ide.eval(false)},
       {c: "ion-ios-play", title: "Run (⌃⏎ or ⌘⏎)", click: () => this.ide.eval(true)},
       inspectorButton
@@ -2163,6 +2165,24 @@ export class IDE {
     localStorage.setItem("eve-saves", JSON.stringify(saves));
     this.documentId = undefined;
     this.loadFile(docId);
+  }
+
+  saveToGist() {
+    // @FIXME: We really need a display name setup for documents.
+    writeToGist(this.documentId || "Untitled.eve", this.editor.toMarkdown(), (err, url) => {
+      if(err) {
+        this.injectNotice("error", "Unable to save file to gist. Check the developer console for more information.");
+        console.error(err);
+      } else {
+        // @FIXME: This needs to be an anchor tag.
+        // @FIXME: info notices need to be dismissible.
+        this.injectNotice("info", `Saved to: ${url}`);
+      }
+    });
+  }
+
+  loadFromGist() {
+    console.error("@TODO: Implement me!");
   }
 
   createDocument(folder:string) {

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2152,7 +2152,6 @@ export class IDE {
     }
     if(code === undefined) {
       console.error(`Unable to load uncached file: '${docId}'`);
-      debugger;
       return false;
     }
     this.loaded = false;

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2118,7 +2118,7 @@ export class IDE {
     // We're loading from a remote gist
     if(docId.indexOf("gist:") === 0 && !content) {
       let gistId = docId.slice(5);
-      if(gistId.indexOf("-")) gistId = gistId.slice(0, gistId.indexOf("-"));
+      if(gistId.indexOf("-") !== -1) gistId = gistId.slice(0, gistId.indexOf("-"));
       let gistUrl = `https://gist.githubusercontent.com/raw/${gistId}`;
       return this.loadFromGist(gistUrl);
     }

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2233,7 +2233,9 @@ export class IDE {
 
   saveToGist() {
     // @FIXME: We really need a display name setup for documents.
+    let savingNotice = this.injectNotice("info", "Saving...");
     writeToGist(this.documentId || "Untitled.eve", this.editor.toMarkdown(), (err, url) => {
+      this.dismissNotice(savingNotice);
       if(err) {
         this.injectNotice("error", "Unable to save file to gist. Check the developer console for more information.");
         console.error(err);
@@ -2299,10 +2301,12 @@ export class IDE {
       }
     }
     if(!existing) {
-      this.notices.push({type, message, time});
+      existing = {type, message, time};
+      this.notices.push(existing);
     }
     this.render();
     this.editor.cm.refresh();
+    return existing;
   }
 
   dismissNotice(notice) {

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -2310,6 +2310,7 @@ export class IDE {
         neueNode[attr] = navNode[attr];
       }
       neueNode.id = neueId;
+      neueNode.name = neueId.split("/").pop();
       neueNode.children = [];
       this.navigator.nodes[neueId] = neueNode;
     }
@@ -2325,6 +2326,9 @@ export class IDE {
 
     this.saveDocument();
     this.navigator.loadDocument(neueId, neueId);
+
+    // @FIXME: Will break in multi-workspace.
+    this.navigator.nodes[this.navigator.rootId].children.push(neueId);
   }
 
   saveToGist() {

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -423,8 +423,8 @@ class Navigator {
         ]} : undefined,
         {c: "flex-spacer"},
 
-        this.open && type === "document" ? {c: "ion-ios-cloud-upload-outline btn", title: "Save to Gist", click: () => this.ide.saveToGist()} : undefined,
-        this.open && type === "document" ? {c: "ion-ios-cloud-download-outline btn", title: "Load from Gist", click: this.openLoadDialog} : undefined,
+        this.open ? {c: "ion-ios-cloud-upload-outline btn", title: "Save to Gist", click: () => this.ide.saveToGist()} : undefined,
+        this.open ? {c: "ion-ios-cloud-download-outline btn", title: "Load from Gist", click: this.openLoadDialog} : undefined,
 
         {c: `${this.open ? "expand-btn" : "collapse-btn"} ion-ios-arrow-back btn`, title: this.open ? "Expand" : "Collapse", click: this.togglePane},
       ]},

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -434,7 +434,7 @@ class Navigator {
 
   loadDialog():Elem {
     return {c: "load-dialog flex-row", children: [
-      {t: "input", c: "flex-spacer", type: "url", autofocus: true, placeholder: "Enter gist url...", input: this.loadDialogInput, keydown: this.loadFromDialog},
+      {t: "input", c: "flex-spacer", type: "url", autofocus: true, placeholder: "Enter gist url to load...", input: this.loadDialogInput, keydown: this.loadFromDialog},
       {c: "btn load-btn ion-arrow-right-b", style: "padding: 0 10", click: this.loadFromDialog}
     ]};
   }

--- a/src/microReact.js
+++ b/src/microReact.js
@@ -171,6 +171,8 @@ var Renderer = (function () {
                 div.setAttribute("download", cur.download);
             if (cur.allowfullscreen !== prev.allowfullscreen)
                 div.setAttribute("allowfullscreen", cur.allowfullscreen);
+            if (cur.autofocus !== prev.autofocus)
+                div.setAttribute("autofocus", cur.autofocus ? true : undefined);
             // animateable properties
             var tween = cur.tween || tempTween;
             if (cur.flex !== prev.flex) {
@@ -431,6 +433,7 @@ var Renderer = (function () {
                 && curA.data === curB.data
                 && curA.download === curB.download
                 && curA.allowfullscreen === curB.allowfullscreen
+                && curA.autofocus === curB.autofocus
                 && curA.placeholder === curB.placeholder
                 && curA.selected === curB.selected
                 && curA.draggable === curB.draggable
@@ -573,4 +576,3 @@ var Renderer = (function () {
     Renderer._compileRenderer = {};
     return Renderer;
 })();
-

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -568,6 +568,24 @@ window.addEventListener("click", function(event) {
     current = current.parentElement;
   }
   client.sendEvent(objs);
+
+  if((target as Element).tagName === "A") {
+    let elem = target as HTMLAnchorElement;
+    // Target location is internal, so we need to rewrite it to respect the IDE's hash segment structure.
+    if(elem.href.indexOf(location.origin) === 0) {
+      let relative = elem.href.slice(location.origin.length + 1);
+      if(relative[0] === "#") relative = relative.slice(1);
+
+
+      let currentHashChunks = location.hash.split("#").slice(1);
+      let ideHash = currentHashChunks[0];
+      if(ideHash[ideHash.length - 1] === "/") ideHash = ideHash.slice(0, -1);
+
+      let modified = "#" + ideHash + "/#" + relative;
+      location.hash = modified;
+      event.preventDefault();
+    }
+  }
 });
 window.addEventListener("dblclick", function(event) {
   let {target} = event;
@@ -739,4 +757,3 @@ function injectProgram(node, elem) {
 export function renderEve() {
   renderer.render([{c: "application-container", postRender: injectProgram}]);
 }
-

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -184,19 +184,13 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
     let {url, hash} = data;
     let path = hash !== "" ? hash : url;
 
-
     let content = path && eveSource.find(path);
 
-    if(!content && config.path) {
+    if(!content && config.path && path.indexOf("gist:") === -1) {
       let workspace = config.internal ? "examples" : "root";
       // @FIXME: This hard-coding isn't technically wrong right now, but it's brittle and poor practice.
       content = eveSource.get(config.path, workspace);
       if(content) path = eveSource.getRelativePath(config.path, workspace);
-    }
-
-    if(!content && config.internal) {
-      content = eveSource.get("quickstart.eve", "examples");
-      if(content) path = eveSource.getRelativePath("quickstart.eve", "examples");
     }
 
     if(content) {
@@ -211,6 +205,7 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
           let content = fs.readFileSync("." + path).toString();
           ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, code: content, withIDE: editor}));
         } else {
+          path = hash || url;
           ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, withIDE: editor}));
         }
 

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -195,7 +195,7 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
     let content = filepath && eveSource.find(filepath);
 
     if(!content && config.path && path.indexOf("gist:") === -1) {
-      let workspace = config.internal ? "examples" : "root";
+      let workspace = "root";
       // @FIXME: This hard-coding isn't technically wrong right now, but it's brittle and poor practice.
       content = eveSource.get(config.path, workspace);
       if(content) path = eveSource.getRelativePath(config.path, workspace);
@@ -279,6 +279,7 @@ export function run() {
   // @FIXME: Split these out!
   eveSource.add("eve", path.join(config.eveRoot, "examples"));
   if(config.internal) {
+    eveSource.add("root", path.join(config.eveRoot, "examples"));
     eveSource.add("examples", path.join(config.eveRoot, "examples"));
   } else {
     eveSource.add("root", config.root);

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -182,9 +182,17 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
   if(data.type === "init") {
     let {editor, runtimeOwner, controlOwner} = config;
     let {url, hash} = data;
-    let path = hash !== "" ? hash : url;
 
-    let content = path && eveSource.find(path);
+
+    let path = url;
+    let filepath = path;
+    if(hash) {
+      path = hash;
+      filepath = hash.split("#")[0];
+      if(filepath[filepath.length - 1] === "/") filepath = filepath.slice(0, -1);
+    }
+
+    let content = filepath && eveSource.find(filepath);
 
     if(!content && config.path && path.indexOf("gist:") === -1) {
       let workspace = config.internal ? "examples" : "root";

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -192,6 +192,11 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
       if(filepath[filepath.length - 1] === "/") filepath = filepath.slice(0, -1);
     }
 
+    if(config.controlOwner === Owner.client) {
+      ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, withIDE: editor}));
+      return;
+    }
+
     let content = filepath && eveSource.find(filepath);
 
     if(!content && config.path && path.indexOf("gist:") === -1) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -168,7 +168,13 @@ export function whollyEnclosed(inner:Range, outer:Range) {
 // Net utilities
 //---------------------------------------------------------
 
+export function dasherize(text:string) {
+  if(text[0] === "/") text = text.slice(1);
+  return text.replace(/\//g, "-");
+}
+
 export function writeToGist(name:string, content:string, callback:(error:Error, url?:string) => void) {
+  name = dasherize(name);
   let request = new XMLHttpRequest();
   request.onreadystatechange = function() {
     if(request.readyState === 4) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -163,3 +163,46 @@ export function whollyEnclosed(inner:Range, outer:Range) {
   let right = comparePositions(inner.to, outer.to);
   return (left === 1 || left === 0) && (right === -1 || right === 0);
 }
+
+//---------------------------------------------------------
+// Net utilities
+//---------------------------------------------------------
+
+export function writeToGist(name:string, content:string, callback:(error:Error, url?:string) => void) {
+  let request = new XMLHttpRequest();
+  request.onreadystatechange = function() {
+    if(request.readyState === 4) {
+      if(request.status !== 201) {
+        return callback(new Error(`HTTP Response: ${request.status}`));
+      }
+      let response:any = JSON.parse(request.responseText);
+      let file = response.files[name];
+      let url = file.raw_url.split("/raw/")[0];
+      let err = (file.truncated) ? new Error("File to large: Maximum gist size is 10mb") : undefined;
+      callback(err, url);
+    }
+  };
+  let payload = {
+    public: true,
+    description: "",
+    files: {}
+  }
+  payload.files[name] = {content: content};
+  request.open("POST", "https://api.github.com/gists");
+  request.send(JSON.stringify(payload));
+}
+
+export function readFromGist(url:string, callback:(error:Error, content?:string) => void) {
+  let request = new XMLHttpRequest();
+  request.onreadystatechange = function() {
+    if(request.readyState === 4) {
+      if(request.status !== 200) {
+        return callback(new Error(`HTTP Response: ${request.status}`));
+      }
+
+      callback(undefined, request.responseText);
+    }
+  }
+  request.open("GET", url);
+  request.send();
+}


### PR DESCRIPTION
Enables

* Saving current document as markdown to gist
* Loading documents from gists in-editor
* Loading documents from gist-formatted file ids in the editor.

Blocking tasks:

- [x] Silently remap local anchor tag hrefs to ignore the IDE portion of the document fragment. This isn't any more broken than it used to be, but the problem becomes more prevalent since the documentId is no longer a known static value.
- [x] Handle saving edits to documents loaded from gists in some reasonable way.

Notes:

- Code quality is lacking here. Improvements are blocked by some refactoring work that isn't critical. it's still worth discussing any specific issues found, but it's important that we revisit this in the near future for cleanup as part of the broader file store rework.