### PR TITLE
0.2.3

### DIFF
--- a/bin/eve.js
+++ b/bin/eve.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+"use strict";
 
 var path = require("path");
 var fs = require("fs");
@@ -8,7 +9,7 @@ var config = require("../build/src/config");
 var Owner = config.Owner;
 var server = require("../build/src/runtime/server");
 
-const argv = minimist(process.argv.slice(2), {boolean: ["server", "editor"]});
+const argv = minimist(process.argv.slice(2), {boolean: ["help", "version", "localControl", "server", "editor"]});
 
 // Since our current development pattern uses npm as its package repository, we treat the nearest ancestor directory with a package.json (inclusive) as the directory's "root".
 function findRoot(root) {
@@ -33,6 +34,42 @@ var internal = false;
 
 var root = findRoot(process.cwd());
 var eveRoot = findRoot(__dirname);
+
+if(argv["help"]) {
+  let pkg = require(path.join(eveRoot, "package.json"));
+  console.log(`
+    Eve ${pkg.version}
+
+    Usage: eve [flags] [file]
+
+    --help          Display this message.
+    --version       Display installed version and exit.
+    --server        Execute code on the server rather than the client.
+    --editor        Display the editor (default if no file is specified).
+    --port <number> Change the port the Eve server listens to (default 8080).
+    --localControl  Entirely disable server interaction. File changes will be
+                    stored in localStorage.
+
+    If the Eve binary is run in a project directory (a directory containing a
+    package.json file), it will use that directory as your workspace. Otherwise
+    Eve will use the built-in examples workspace.
+
+    If a file is provided, Eve will run it in application-only mode unless the
+    --editor flag is supplied.
+
+    Please refer questions and comments to the mailing list:
+    https://groups.google.com/forum/#!forum/eve-talk
+
+    Please report bugs via GH issues:
+    https://github.com/witheve/eve/issues
+`);
+  process.exit(0);
+}
+if(argv["version"]) {
+  let pkg = require(path.join(eveRoot, "package.json"));
+  console.log(pkg.version);
+  process.exit(0);
+}
 
 
 // If we're executing within the eve module/repo, we're running internally and should expose our examples, src, etc.

--- a/bin/eve.js
+++ b/bin/eve.js
@@ -7,6 +7,7 @@ var minimist = require("minimist");
 
 var config = require("../build/src/config");
 var Owner = config.Owner;
+var Mode = config.Mode;
 var server = require("../build/src/runtime/server");
 
 const argv = minimist(process.argv.slice(2), {boolean: ["help", "version", "localControl", "server", "editor"]});
@@ -94,6 +95,9 @@ if(!filepath) {
     filepath = filepath.replace(/\\/g, "/");
   }
 }
+
+let mode = Mode.workspace;
+if(filepath) mode = Mode.file
 
 var opts = {internal: internal, runtimeOwner: runtimeOwner, controlOwner: controlOwner, editor: editor, port: port, path: filepath, internal: internal, root: root, eveRoot: eveRoot};
 config.init(opts);

--- a/bin/eve.js
+++ b/bin/eve.js
@@ -97,9 +97,9 @@ if(!filepath) {
 }
 
 let mode = Mode.workspace;
-if(filepath) mode = Mode.file
+if(filepath && !editor) mode = Mode.file
 
-var opts = {internal: internal, runtimeOwner: runtimeOwner, controlOwner: controlOwner, editor: editor, port: port, path: filepath, internal: internal, root: root, eveRoot: eveRoot};
+var opts = {internal: internal, runtimeOwner: runtimeOwner, controlOwner: controlOwner, editor: editor, port: port, path: filepath, internal: internal, root: root, eveRoot: eveRoot, mode};
 config.init(opts);
 
 server.run(opts);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "witheve",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Programming designed for humans",
   "keywords": ["language", "ide", "relational", "database", "dataflow"],
   "homepage": "http://witheve.com",

--- a/scripts/build-dist.ts
+++ b/scripts/build-dist.ts
@@ -22,7 +22,6 @@ function buildDist(callback:() => void) {
   let tracker = new Tracker(callback);
   build(() => {
     mkdirp.sync("dist/build");
-    mkdirp.sync("dist/css");
 
     var index = fs.readFileSync("./index.html", "utf-8");
     if(ENABLE_ANALYTICS) {
@@ -34,13 +33,16 @@ function buildDist(callback:() => void) {
     copy("./build/workspaces.js", "./dist/build/workspaces.js", tracker.track("copy packaged workspaces"));
 
 
-    for(let pattern of ["build/src/**/*.js", "build/src/**/*.js.map", "src/**/*.css", "css/**/*.css", "examples/**/*.css"]) {
+    for(let pattern of ["build/src/**/*", "assets/**/*"]) {
       let matches = glob.sync(pattern);
       for(let match of matches) {
+        if(fs.statSync(match).isDirectory()) continue;
         let pathname = match.split("/").slice(0, -1).join("/");
 
         // @NOTE: Arghhh
-        mkdirp.sync("dist/" + pathname);
+        if(!fs.existsSync("dist/" + pathname)) {
+          mkdirp.sync("dist/" + pathname);
+        }
         copy(match, "dist/" + match, tracker.track("copy build artifacts"));
       }
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -284,23 +284,23 @@ export class EveClient {
       browser.init(data.code);
     }
     if(this.showIDE) {
-      // Ensure the URL bar is in sync with the server.
-      // @FIXME: This back and forth of control over where we are
-      // is an Escherian nightmare.
-
-      if(!data.path) {
-        history.pushState({}, "", window.location.pathname);
-      }
+      let path = data.path;
+      if(path === undefined) path = location.hash && location.hash.slice(1);
+      //history.replaceState({}, "", window.location.pathname);
 
       this.ide = new IDE();
       this.ide.local = this.localControl;
       initIDE(this);
       this.ide.render();
-      if(data.path && data.path.length > 2) {
-        let currentHashChunks = location.hash.split("#").slice(1);
+      let found = false;
+      if(path && path.length > 2) {
+        let currentHashChunks = path.split("#");//.slice(1);
         let docId = currentHashChunks[0];
         if(docId && docId[docId.length - 1] === "/") docId = docId.slice(0, -1);
-        this.ide.loadFile(docId, data.code);
+        found = this.ide.loadFile(docId, data.code);
+      }
+      if(!found && data.internal) {
+        this.ide.loadFile("/examples/quickstart.eve");
       }
     }
     onHashChange({});

--- a/src/client.ts
+++ b/src/client.ts
@@ -297,7 +297,10 @@ export class EveClient {
       initIDE(this);
       this.ide.render();
       if(data.path && data.path.length > 2) {
-        this.ide.loadFile(data.path, data.code);
+        let currentHashChunks = location.hash.split("#").slice(1);
+        let docId = currentHashChunks[0];
+        if(docId && docId[docId.length - 1] === "/") docId = docId.slice(0, -1);
+        this.ide.loadFile(docId, data.code);
       }
     }
     onHashChange({});
@@ -446,7 +449,15 @@ function initIDE(client:EveClient) {
     client.send({type: "close"});
     client.send({scope: "root", type: "parse", code})
     client.send({type: "eval", persist: false});
+
     let url = `${location.pathname}#${documentId}`;
+    let currentHashChunks = location.hash.split("#").slice(1);
+    let curId = currentHashChunks[0];
+    if(curId && curId[curId.length - 1] === "/") curId = curId.slice(0, -1);
+    if(curId === documentId && currentHashChunks[1]) {
+      url += "/#" + currentHashChunks[1];
+    }
+
     history.pushState({}, "", url + location.search);
     analyticsEvent("load-document", documentId);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,17 @@
 export enum Owner {client, server};
+export enum Mode {workspace, file};
 
-export interface Config {path?:string, runtimeOwner?: Owner, controlOwner?: Owner, port?:number, editor?: boolean, root?: string, eveRoot?: string, internal?: boolean}
+export interface Config {
+  path?:string,
+  runtimeOwner?: Owner,
+  controlOwner?: Owner,
+  port?:number,
+  editor?: boolean,
+  root?: string,
+  eveRoot?: string,
+  internal?: boolean,
+  mode?: Mode
+}
 
 export var config:Config = {};
 

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -419,7 +419,7 @@ class Navigator {
       {c: "controls", children: [
         this.open ? {c: `up-btn flex-row  ${(this.currentId === this.rootId) ? "disabled" : ""}`, click: this.navigate, children: [
           {c:  "up-icon ion-android-arrow-up"},
-          {c: "label", text: "examples"}
+          {c: "label", text: "workspaces"}
         ]} : undefined,
         {c: "flex-spacer"},
 

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -10,7 +10,7 @@ import * as express from "express";
 import * as bodyParser from "body-parser";
 import * as minimist from "minimist";
 
-import {config, Config, Owner} from "../config";
+import {config, Config, Owner, Mode} from "../config";
 import {ActionImplementations} from "./actions";
 import {PersistedDatabase} from "./databases/persisted";
 import {HttpDatabase} from "./databases/node/http";
@@ -180,52 +180,52 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
   let data = JSON.parse(message);
 
   if(data.type === "init") {
-    let {editor, runtimeOwner, controlOwner} = config;
-    let {url, hash} = data;
+    let {editor, runtimeOwner, controlOwner, internal, mode} = config;
+    let {hash} = data;
 
+    let content:string;
+    let path:string;
 
-    let path = url;
-    let filepath = path;
-    if(hash) {
-      path = hash;
-      filepath = hash.split("#")[0];
+    // If the client is locally controlled it's in charge of its own file management.
+    // If it's requesting a gist, it needs to fetch elsewhere too.
+    // This is pretty hacky, but we'll clean it up in post.
+    if(config.controlOwner === Owner.client ||
+       hash && hash.indexOf("gist:") === 0) {
+      return ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, internal, withIDE: editor}));
+    }
+
+    // If we're in file mode, the only valid file to serve is the one specified in `config.path`.
+    if(mode === Mode.file) {
+      content = eveSource.find(config.path);
+      path = config.path;
+    }
+
+    // Otherwise, anything goes. First we check if the client has requested a specific file in the URL hash.
+    if(!content && hash) {
+      // @FIXME: This code to strip the editor hash segment out really needs to be abstacted.
+      let filepath = hash.split("#")[0];
       if(filepath[filepath.length - 1] === "/") filepath = filepath.slice(0, -1);
+
+      content = filepath && eveSource.find(filepath);
+      path = hash;
     }
 
-    if(config.controlOwner === Owner.client) {
-      ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, withIDE: editor}));
-      return;
-    }
-
-    let content = filepath && eveSource.find(filepath);
-
-    if(!content && config.path && path.indexOf("gist:") === -1) {
+    // If we've got a path to run with, use it as the default.
+    if(!content && config.path) {
       let workspace = "root";
       // @FIXME: This hard-coding isn't technically wrong right now, but it's brittle and poor practice.
       content = eveSource.get(config.path, workspace);
-      if(content) path = eveSource.getRelativePath(config.path, workspace);
+      path = eveSource.getRelativePath(config.path, workspace);
     }
 
-    if(content) {
-      ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, code: content, withIDE: editor}));
-      if(runtimeOwner === Owner.server) {
-        client.load(content, "user");
-      }
-    } else {
-      // @FIXME: Do we still need this fallback for anything? Cases where we need to run an eve file outside of a project?
-      fs.stat("." + path, (err, stats) => {
-        if(!err && stats.isFile()) {
-          let content = fs.readFileSync("." + path).toString();
-          ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, code: content, withIDE: editor}));
-        } else {
-          path = hash || url;
-          ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, withIDE: editor}));
-        }
+    // If we can't find the config path in a workspace, try finding it on disk.
+    if(!content && config.path && fs.existsSync("." + path)) {
+      content = fs.readFileSync("." + path).toString();
+    }
 
-        if(runtimeOwner === Owner.server) {
-          client.load(content, "user");
-        }
-      });
+    ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, code: content, internal, withIDE: editor}));
+    if(runtimeOwner === Owner.server) {
+      client.load(content, "user");
     }
   } else if(data.type === "save"){
     eveSource.save(data.path, data.code);

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -185,6 +185,7 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
 
     let content:string;
     let path:string;
+    let isLocal = hash.indexOf("gist:") === 0;
 
     // If we're in file mode, the only valid file to serve is the one specified in `config.path`.
     if(mode === Mode.file) {
@@ -193,7 +194,7 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
     }
 
     // Otherwise, anything goes. First we check if the client has requested a specific file in the URL hash.
-    if(mode === Mode.workspace && hash) {
+    if(!isLocal && mode === Mode.workspace && hash) {
       // @FIXME: This code to strip the editor hash segment out really needs to be abstacted.
       let filepath = hash.split("#")[0];
       if(filepath[filepath.length - 1] === "/") filepath = filepath.slice(0, -1);
@@ -203,7 +204,7 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
     }
 
     // If we've got a path to run with, use it as the default.
-    if(!content && config.path) {
+    if(!isLocal && !content && config.path) {
       let workspace = "root";
       // @FIXME: This hard-coding isn't technically wrong right now, but it's brittle and poor practice.
       content = eveSource.get(config.path, workspace);
@@ -211,7 +212,7 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
     }
 
     // If we can't find the config path in a workspace, try finding it on disk.
-    if(!content && config.path && fs.existsSync("." + path)) {
+    if(!isLocal && !content && config.path && fs.existsSync("." + path)) {
       content = fs.readFileSync("." + path).toString();
     }
 

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -186,14 +186,6 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
     let content:string;
     let path:string;
 
-    // If the client is locally controlled it's in charge of its own file management.
-    // If it's requesting a gist, it needs to fetch elsewhere too.
-    // This is pretty hacky, but we'll clean it up in post.
-    if(config.controlOwner === Owner.client ||
-       hash && hash.indexOf("gist:") === 0) {
-      return ws.send(JSON.stringify({type: "initProgram", runtimeOwner, controlOwner, path, internal, withIDE: editor}));
-    }
-
     // If we're in file mode, the only valid file to serve is the one specified in `config.path`.
     if(mode === Mode.file) {
       content = eveSource.find(config.path);
@@ -201,7 +193,7 @@ function IDEMessageHandler(client:SocketRuntimeClient, message) {
     }
 
     // Otherwise, anything goes. First we check if the client has requested a specific file in the URL hash.
-    if(!content && hash) {
+    if(mode === Mode.workspace && hash) {
       // @FIXME: This code to strip the editor hash segment out really needs to be abstacted.
       let filepath = hash.split("#")[0];
       if(filepath[filepath.length - 1] === "/") filepath = filepath.slice(0, -1);


### PR DESCRIPTION
Blocked by #675.

This pull handles various cleanup and bugfix tasks requires to make 0.2.3 shippable for `play.witheve.com` and NPM.

`play.witheve.com` is two versions old now and is missing *many* hotfixes, so this needs to get out Monday or Tuesday next week barring show-stoppers.