### PR TITLE
Make client/browser checks for multiton attribute values use set semantics

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -83,7 +83,13 @@ function handleDiff(state, diff) {
     dirty.insert(e, a);
 
     if(!entity[a]) entity[a] = [];
-    entity[a].push(v);
+    let isSingleValueAttr = a == "value" ||
+                            a == "tag" ||
+                            a == "sort" ||
+                            a == "checked";
+    if(!(isSingleValueAttr && entity[a].length == 1 && entity[a][0] === v)) {
+      entity[a].push(v);
+    }
 
     // Update indexes
     if(a === "tag") indexes.byTag.insert(v, e);


### PR DESCRIPTION
Following on from https://github.com/witheve/Eve/issues/624

Now I know the correct way to deal with default values, I can file a better bug report and this PR. Given the following example:

```
commit @browser
  [#label text: "I want to be asked a question:" children: [#input type: "checkbox" name: "panel" value: "show"]]
```
```
search @browser
  input = if [#input name: "color" checked: true] then [#input name: "color" checked: true]
          else [#input name: "color" value: "other"]
bind @browser
  input.checked := true
```
```
search @browser
  [#input name: "panel" value: "show" checked: true]
bind @browser
  [#h3 text: "What's your favorite color?"]
  [#label text: "Red" children: [#input type: "radio" name: "color" value: "red"]]
  [#label text: "Blue" children: [#input type: "radio" name: "color" value: "blue"]]
  [#label text: "Some other color" children: [#input type: "radio" name: "color" value: "other"]]
```

Steps to reproduce:

1. Click "I want to be asked a question"
2. Click "Red"
3. Click "I want to be asked a question" twice

Actual behaviour:
See the error: "Unable to set 'checked' multiple times on entity" in the console.
Note that now nothing is selected.

Expected behaviour:
No error.
The default is still selected.

Proposed fix in this PR: since it appears that although Eve attribute values behave as sets, they can end up with multiple identical values, all the checks of whether they are multiton sets must be changed from checking if there is more than one array element to check if there is more than one distinct value. The other possible fix would be to make sure it was impossible for the attribute values to have non-distinct values, but some shallow investigation led me to believe the current situation of "multisets that get interpreted as sets" is by-design.

P.S. Here is a snippet I used for tracing what was going on in my example:
```
search @browser
  input = [#input name value]
  checked = if input.checked then "✔"
            else "✘"
bind @browser
  [#div text: "Current status" children:
    [#div text: "{{name}} {{value}} {{checked}}"]]
```
```
search @event @session @browser
  [#change element: [#input name value] checked]
  [#time frames]
commit @browser
  [#div sort: frames text: "{{frames}}: {{name}} {{value}} => {{checked}}"]
```