### PR TITLE
Initdb - preload server with records from json

### DIFF
--- a/bin/eve.js
+++ b/bin/eve.js
@@ -54,7 +54,7 @@ if(argv["help"]) {
     --json          Load the passed json file into @init. One additional
                     colon separated argument to specify the target database,
                     an additional to add the passed tag to each json record
-                    [[tag:]database]:filename
+                    filename[:database[:tag]]
 
     If the Eve binary is run in a project directory (a directory containing a
     package.json file), it will use that directory as your workspace. Otherwise

--- a/bin/eve.js
+++ b/bin/eve.js
@@ -104,6 +104,8 @@ if(!filepath) {
 let mode = Mode.workspace;
 if(filepath && !editor) mode = Mode.file
 
+if (!Array.isArray(initJsonDB) && initJsonDB) initJsonDB = [initJsonDB];
+
 var opts = {internal: internal, runtimeOwner: runtimeOwner, controlOwner: controlOwner, editor: editor, port: port, path: filepath, internal: internal, root: root, eveRoot: eveRoot, mode, initJsonDB:initJsonDB};
 config.init(opts);
 

--- a/bin/eve.js
+++ b/bin/eve.js
@@ -10,7 +10,8 @@ var Owner = config.Owner;
 var Mode = config.Mode;
 var server = require("../build/src/runtime/server");
 
-const argv = minimist(process.argv.slice(2), {boolean: ["help", "version", "localControl", "server", "editor"]});
+const argv = minimist(process.argv.slice(2), {boolean: ["help", "version", "localControl", "server", "editor"],
+                                              string:["json"]});
 
 // Since our current development pattern uses npm as its package repository, we treat the nearest ancestor directory with a package.json (inclusive) as the directory's "root".
 function findRoot(root) {
@@ -32,7 +33,7 @@ var controlOwner = argv["localControl"] ? Owner.client : Owner.server;
 var editor = argv["editor"] || false;
 var filepath = argv["_"][0];
 var internal = false;
-
+var initJsonDB = argv["json"]
 var root = findRoot(process.cwd());
 var eveRoot = findRoot(__dirname);
 
@@ -50,6 +51,10 @@ if(argv["help"]) {
     --port <number> Change the port the Eve server listens to (default 8080).
     --localControl  Entirely disable server interaction. File changes will be
                     stored in localStorage.
+    --json          Load the passed json file into @init. One additional
+                    colon separated argument to specify the target database,
+                    an additional to add the passed tag to each json record
+                    [[tag:]database]:filename
 
     If the Eve binary is run in a project directory (a directory containing a
     package.json file), it will use that directory as your workspace. Otherwise
@@ -99,7 +104,7 @@ if(!filepath) {
 let mode = Mode.workspace;
 if(filepath && !editor) mode = Mode.file
 
-var opts = {internal: internal, runtimeOwner: runtimeOwner, controlOwner: controlOwner, editor: editor, port: port, path: filepath, internal: internal, root: root, eveRoot: eveRoot, mode};
+var opts = {internal: internal, runtimeOwner: runtimeOwner, controlOwner: controlOwner, editor: editor, port: port, path: filepath, internal: internal, root: root, eveRoot: eveRoot, mode, initJsonDB:initJsonDB};
 config.init(opts);
 
 server.run(opts);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import {Database} from "./runtime/runtime";
+
 export enum Owner {client, server};
 export enum Mode {workspace, file};
 
@@ -11,7 +13,8 @@ export interface Config {
   eveRoot?: string,
   internal?: boolean,
   mode?: Mode,
-  initJsonDB? : string[]
+  initJsonDB? : string[],
+  databases? : {[name:string]:Database}
 }
 
 export var config:Config = {};

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,7 +10,8 @@ export interface Config {
   root?: string,
   eveRoot?: string,
   internal?: boolean,
-  mode?: Mode
+  mode?: Mode,
+  initJsonDB? : any
 }
 
 export var config:Config = {};

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,7 +11,7 @@ export interface Config {
   eveRoot?: string,
   internal?: boolean,
   mode?: Mode,
-  initJsonDB? : any
+  initJsonDB? : string[]
 }
 
 export var config:Config = {};

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -55,9 +55,9 @@ class HTTPRuntimeClient extends RuntimeClient {
       "shared": shared,
       "browser": new Database(),
     }
-    var uniondb = {}
-    for (var key in dbs) uniondb[key] = dbs[key];
-    for (var key in databases) uniondb[key] = databases[key];
+    let uniondb = {}
+    for (let key in dbs) uniondb[key] = dbs[key];
+    for (let key in databases) uniondb[key] = databases[key];
     super(uniondb);
     this.server = server;
   }
@@ -170,9 +170,9 @@ class SocketRuntimeClient extends RuntimeClient {
       dbs["editor"] = new BrowserEditorDatabase();
       dbs["inspector"] = new BrowserInspectorDatabase();
     }
-    var uniondb = {}
-    for (var key in dbs) uniondb[key] = dbs[key];
-    for (var key in databases) uniondb[key] = databases[key]
+    let uniondb = {}
+    for (let key in dbs) uniondb[key] = dbs[key];
+    for (let key in databases) uniondb[key] = databases[key]
     super(uniondb);
     this.socket = socket;
   }
@@ -278,31 +278,29 @@ function initWebsocket(wss, databases, withIDE:boolean) {
   });
 }
 
-function loadDatabases(description) {
-  var databases = {};
-  var dbs = description;
-  if (!Array.isArray(dbs)) dbs = [dbs];
-  var arrayLength = dbs.length;
+function loadDatabases(descriptions) {
+  let databases = {};
+  let arrayLength = descriptions.length;
   let multi = new MultiIndex();
   let changes =  new Changes(multi);
 
-  for (var i = 0; i < arrayLength; i++) {
-    var database = "init";
-    var prefix = undefined;
-    var terms = dbs[i].split(":")
-    var count = 0;
+  for (let i = 0; i < arrayLength; i++) {
+    let database = "init";
+    let tag = undefined;
+    let terms = descriptions[i].split(":")
+    let count = 0;
 
-    if (terms.length == 3) prefix = terms[count++];
-    if (terms.length == 2) database = terms[count++];
-    var data = fs.readFileSync(terms[count]).toString();
+    if (terms.length == 3) tag = terms[2];
+    if (terms.length == 2) database = terms[1];
+    let data = fs.readFileSync(terms[0]).toString();
 
     if (!databases[database]) {
       databases[database] = new Database;
       multi.register(database, databases[database].index)
     }
     let id = fromJS(changes, JSON.parse(data), databases[database].id, database);
-    if (prefix) {
-      changes.store(database, id, "tag", prefix, "prefix");
+    if (tag) {
+      changes.store(database, id, "tag", tag, "init");
     }
   }
   changes.commit();
@@ -336,7 +334,7 @@ export function run() {
     }
   }
 
-  var databases;
+  let databases;
   if (config.initJsonDB) {
     databases = loadDatabases(config.initJsonDB);
   }

--- a/src/runtime/server.ts
+++ b/src/runtime/server.ts
@@ -19,6 +19,9 @@ import {Database} from "./runtime";
 import {RuntimeClient} from "./runtimeClient";
 import {BrowserViewDatabase, BrowserEditorDatabase, BrowserInspectorDatabase} from "./databases/browserSession";
 import * as eveSource from "./eveSource";
+import {Changes} from "./changes";
+import {MultiIndex} from "./indexes";
+import {fromJS} from "./util/eavs";
 
 //---------------------------------------------------------------------
 // Constants
@@ -44,7 +47,7 @@ global["browser"] = false;
 
 class HTTPRuntimeClient extends RuntimeClient {
   server: ServerDatabase;
-  constructor() {
+  constructor(databases) {
     let server = new ServerDatabase();
     const dbs = {
       "http": new HttpDatabase(),
@@ -52,7 +55,10 @@ class HTTPRuntimeClient extends RuntimeClient {
       "shared": shared,
       "browser": new Database(),
     }
-    super(dbs);
+    var uniondb = {}
+    for (var key in dbs) uniondb[key] = dbs[key];
+    for (var key in databases) uniondb[key] = databases[key];
+    super(uniondb);
     this.server = server;
   }
 
@@ -95,7 +101,7 @@ function handleStatic(request, response) {
   };
 }
 
-function createExpressApp() {
+function createExpressApp(databases) {
   let filepath = config.path;
   const app = express();
 
@@ -115,7 +121,7 @@ function createExpressApp() {
     let client;
     // @FIXME: When Owner.both is added this needs updated.
     if(config.runtimeOwner === Owner.server) {
-      client = new HTTPRuntimeClient();
+      client = new HTTPRuntimeClient(databases);
       let content = "";
       if(filepath) content = fs.readFileSync(filepath).toString();
       client.load(content, "user");
@@ -131,7 +137,7 @@ function createExpressApp() {
     let client;
     // @FIXME: When Owner.both is added this needs updated.
     if(config.runtimeOwner === Owner.server) {
-      client = new HTTPRuntimeClient();
+      client = new HTTPRuntimeClient(databases);
       let content = "";
       if(filepath) content = fs.readFileSync(filepath).toString();
       client.load(content, "user");
@@ -154,7 +160,7 @@ function createExpressApp() {
 class SocketRuntimeClient extends RuntimeClient {
   socket: WebSocket;
 
-  constructor(socket:WebSocket, withIDE:boolean) {
+  constructor(socket:WebSocket, databases, withIDE:boolean) {
     const dbs = {
       "http": new HttpDatabase(),
       "shared": shared,
@@ -164,7 +170,10 @@ class SocketRuntimeClient extends RuntimeClient {
       dbs["editor"] = new BrowserEditorDatabase();
       dbs["inspector"] = new BrowserInspectorDatabase();
     }
-    super(dbs);
+    var uniondb = {}
+    for (var key in dbs) uniondb[key] = dbs[key];
+    for (var key in databases) uniondb[key] = databases[key]
+    super(uniondb);
     this.socket = socket;
   }
 
@@ -251,9 +260,9 @@ function MessageHandler(client:SocketRuntimeClient, message) {
   }
 }
 
-function initWebsocket(wss, withIDE:boolean) {
+function initWebsocket(wss, databases, withIDE:boolean) {
   wss.on('connection', function connection(ws) {
-    let client = new SocketRuntimeClient(ws, withIDE);
+    let client = new SocketRuntimeClient(ws, databases, withIDE);
     let handler = withIDE ? IDEMessageHandler : MessageHandler;
     if(!withIDE) {
       // we need to initialize
@@ -268,6 +277,38 @@ function initWebsocket(wss, withIDE:boolean) {
     });
   });
 }
+
+function loadDatabases(description) {
+  var databases = {};
+  var dbs = description;
+  if (!Array.isArray(dbs)) dbs = [dbs];
+  var arrayLength = dbs.length;
+  let multi = new MultiIndex();
+  let changes =  new Changes(multi);
+
+  for (var i = 0; i < arrayLength; i++) {
+    var database = "init";
+    var prefix = undefined;
+    var terms = dbs[i].split(":")
+    var count = 0;
+
+    if (terms.length == 3) prefix = terms[count++];
+    if (terms.length == 2) database = terms[count++];
+    var data = fs.readFileSync(terms[count]).toString();
+
+    if (!databases[database]) {
+      databases[database] = new Database;
+      multi.register(database, databases[database].index)
+    }
+    let id = fromJS(changes, JSON.parse(data), databases[database].id, database);
+    if (prefix) {
+      changes.store(database, id, "tag", prefix, "prefix");
+    }
+  }
+  changes.commit();
+  return databases;
+}
+
 
 //---------------------------------------------------------------------
 // Go!
@@ -295,12 +336,17 @@ export function run() {
     }
   }
 
-  let app = createExpressApp();
+  var databases;
+  if (config.initJsonDB) {
+    databases = loadDatabases(config.initJsonDB);
+  }
+
+  let app = createExpressApp(databases);
   let server = http.createServer(app);
 
   let WebSocketServer = require('ws').Server;
   let wss = new WebSocketServer({server});
-  initWebsocket(wss, config.editor);
+  initWebsocket(wss, databases, config.editor);
 
   server.listen(config.port, function(){
     console.log(`Eve is available at http://localhost:${config.port}. Point your browser there to access the Eve editor.`);


### PR DESCRIPTION
this patch creates a -json flag which reads one or more passed json files, and stores the objects in @init 

if the file is preceded by a colon separated field foo:file, then "foo" is created as the target database

if the database is preceded by a colon separated tag, then each json object in file will have #tag added to its record (for tables dumped as sets of objects)
