### PR TITLE
get all the tests running again, fix a broken one

### DIFF
--- a/test/join.ts
+++ b/test/join.ts
@@ -191,7 +191,7 @@ test("search with attribute having multiple values in parenthesis with a functio
   assert.end();
 })
 
-test.only("sub-records in a parenthesis pick up their parent as part of their identity", (assert) => {
+test("sub-records in a parenthesis pick up their parent as part of their identity", (assert) => {
   let expected = {
     insert: [
       ["a", "tag", "person"],
@@ -676,10 +676,12 @@ test("creating an object with multiple values for an attribute", (assert) => {
 test("creating an object with multiple complex values for an attribute", (assert) => {
   let expected = {
     insert: [
-      ["2", "tag", "person"],
-      ["2", "name", "chris"],
+      ["4", "tag", "person"],
+      ["4", "name", "chris"],
       ["6", "tag", "foo"],
+      ["6", "eve-auto-index", 1],
       ["8", "tag", "bar"],
+      ["8", "eve-auto-index", 2],
       ["12","tag","dude"],
       ["12","dude","6"],
       ["12","dude","8"],


### PR DESCRIPTION
A `test.only(` got checked in, which means only one of the tests are currently running.