### PR TITLE
mark a few providers as being internal

### DIFF
--- a/src/runtime/parser.ts
+++ b/src/runtime/parser.ts
@@ -1098,7 +1098,7 @@ export class Parser extends chev.Parser {
       });
       from.push(self.CONSUME(CloseParen));
       let variable = self.block.toVariable(`is|${op.startLine}|${op.startColumn}`, true);
-      let is = makeNode("expression", {variable, op: "and", args: expressions, from});
+      let is = makeNode("expression", {variable, op: "eve-internal/and", args: expressions, from});
       self.block.addUsage(variable, is);
       self.block.expression(is);
       return is;
@@ -1329,7 +1329,7 @@ export class Parser extends chev.Parser {
         return args[0];
       }
       let variable = self.block.toVariable(`concat|${start.startLine}|${start.startColumn}`, true);
-      let expression = makeNode("expression", {op: "concat", args, variable, from});
+      let expression = makeNode("expression", {op: "eve-internal/concat", args, variable, from});
       self.block.addUsage(variable, expression);
       self.block.expression(expression);
       return expression;

--- a/src/runtime/providers/logical.ts
+++ b/src/runtime/providers/logical.ts
@@ -76,78 +76,6 @@ class AssertValue extends Constraint {
   }
 }
 
-class And extends Constraint {
-  resolveProposal(proposal, prefix) {
-    let {args} = this.resolve(prefix);
-    let result = true;
-    for(let arg of args) {
-      if(arg === false) {
-        result = false;
-        break;
-      }
-    }
-    return [result];
-  }
-
-  test(prefix) {
-    let {args, returns} = this.resolve(prefix);
-    let result = true;
-    for(let arg of args) {
-      if(arg === false) {
-        result = false;
-        break;
-      }
-    }
-    return result === returns[0];
-  }
-
-  getProposal(tripleIndex, proposed, prefix) {
-    let proposal = this.proposalObject;
-    proposal.providing = proposed;
-    proposal.cardinality = 1;
-    return proposal;
-  }
-}
-
-
-class Or extends Constraint {
-  // To resolve a proposal, we concatenate our resolved args
-  resolveProposal(proposal, prefix) {
-    let {args} = this.resolve(prefix);
-    let result = false;
-    for(let arg of args) {
-      if(arg !== false) {
-        result = true;
-        break;
-      }
-    }
-    return [result];
-  }
-
-  // We accept a prefix if the return is equivalent to concatentating
-  // all the args
-  test(prefix) {
-    let {args, returns} = this.resolve(prefix);
-    let result = false;
-    for(let arg of args) {
-      if(arg !== false) {
-        result = true;
-        break;
-      }
-    }
-    return result === returns[0];
-  }
-
-  // concat always returns cardinality 1
-  getProposal(tripleIndex, proposed, prefix) {
-    let proposal = this.proposalObject;
-    proposal.providing = proposed;
-    proposal.cardinality = 1;
-    return proposal;
-  }
-}
-
-
 class Toggle extends Constraint {
   static AttributeMapping = {
     "value": 0,
@@ -170,12 +98,56 @@ class Toggle extends Constraint {
   }
 }
 
+//---------------------------------------------------------------------
+// Internal logical providers
+//---------------------------------------------------------------------
+
+// InternalAnd is used as the function that is evaluated for is() forms.
+// Is causes all boolean operators to return and then we wrap the returned
+// values in InternalAnd
+class InternalAnd extends Constraint {
+  resolveProposal(proposal, prefix) {
+    let {args} = this.resolve(prefix);
+    let result = true;
+    for(let arg of args) {
+      if(arg === false) {
+        result = false;
+        break;
+      }
+    }
+    return [result];
+  }
+
+  test(prefix) {
+    let {args, returns} = this.resolve(prefix);
+    let result = true;
+    for(let arg of args) {
+      if(arg === false) {
+        result = false;
+        break;
+      }
+    }
+    return result === returns[0];
+  }
+
+  getProposal(tripleIndex, proposed, prefix) {
+    let proposal = this.proposalObject;
+    proposal.providing = proposed;
+    proposal.cardinality = 1;
+    return proposal;
+  }
+}
+
+//---------------------------------------------------------------------
+// Mappings
+//---------------------------------------------------------------------
+
 providers.provide(">", GreaterThan);
 providers.provide("<", LessThan);
 providers.provide("<=", LessThanEqualTo);
 providers.provide(">=", GreaterThanEqualTo);
 providers.provide("!=", NotEqual);
 providers.provide("=", Equal);
-providers.provide("and", And);
-providers.provide("or", Or);
 providers.provide("toggle", Toggle);
+
+providers.provide("eve-internal/and", InternalAnd);

--- a/src/runtime/providers/string.ts
+++ b/src/runtime/providers/string.ts
@@ -5,32 +5,9 @@
 import {Constraint} from "../join";
 import * as providers from "./index";
 
-// Concat strings together. Args expects a set of variables/string constants
-// to concatenate together and an array with a single return variable
-class Concat extends Constraint {
-  // To resolve a proposal, we concatenate our resolved args
-  resolveProposal(proposal, prefix) {
-    let {args} = this.resolve(prefix);
-    return [args.join("")];
-  }
-
-  // We accept a prefix if the return is equivalent to concatentating
-  // all the args
-  test(prefix) {
-    let {args, returns} = this.resolve(prefix);
-    return args.join("") === returns[0];
-  }
-
-  // concat always returns cardinality 1
-  getProposal(tripleIndex, proposed, prefix) {
-    let proposal = this.proposalObject;
-    proposal.providing = proposed;
-    proposal.cardinality = 1;
-    return proposal;
-  }
-}
-
-
+//---------------------------------------------------------------------
+// Providers
+//---------------------------------------------------------------------
 
 class Split extends Constraint {
   static AttributeMapping = {
@@ -285,7 +262,7 @@ class Length extends Constraint {
 
   test(prefix) {
     let {args, returns} = this.resolve(prefix);
-    let [text, az] = args;   
+    let [text, az] = args;
     if(!this.validAsOption(az)) return false;
     if(typeof text !== "string") return false;
     return this.getLength(text, az) === returns[0];
@@ -329,9 +306,44 @@ class Length extends Constraint {
   }
 }
 
-providers.provide("length", Length);
-providers.provide("concat", Concat);
+//---------------------------------------------------------------------
+// Internal providers
+//---------------------------------------------------------------------
+
+// InternalConcat is used for the implementation of string embedding, e.g.
+// "foo {{name}}". Args expects a set of variables/string constants
+// to concatenate together and an array with a single return variable
+class InternalConcat extends Constraint {
+  // To resolve a proposal, we concatenate our resolved args
+  resolveProposal(proposal, prefix) {
+    let {args} = this.resolve(prefix);
+    return [args.join("")];
+  }
+
+  // We accept a prefix if the return is equivalent to concatentating
+  // all the args
+  test(prefix) {
+    let {args, returns} = this.resolve(prefix);
+    return args.join("") === returns[0];
+  }
+
+  // concat always returns cardinality 1
+  getProposal(tripleIndex, proposed, prefix) {
+    let proposal = this.proposalObject;
+    proposal.providing = proposed;
+    proposal.cardinality = 1;
+    return proposal;
+  }
+}
+
+//---------------------------------------------------------------------
+// Mappings
+//---------------------------------------------------------------------
+
 providers.provide("split", Split);
 providers.provide("substring", Substring);
 providers.provide("convert", Convert);
 providers.provide("urlencode", Urlencode);
+providers.provide("length", Length);
+
+providers.provide("eve-internal/concat", InternalConcat);


### PR DESCRIPTION
There are a few functions that aren't meant for end-users that the runtime itself uses. This PR renames those and adds comments to make that clearer so people don't waste their time trying to get them to work.