### PR TITLE
Optimize join by skipping unnecessary proposals

### DIFF
--- a/src/runtime/join.ts
+++ b/src/runtime/join.ts
@@ -750,6 +750,10 @@ function joinRound(multiIndex: MultiIndex, providers: ProposalProvider[], prefix
       bestProposal = proposed;
       bestProvider = provider;
       bestProviderIx = ix;
+      if(proposed.cardinality === 0) {
+        solverInfo[ix]++;
+        break;
+      }
     }
     ix++;
   }
@@ -758,7 +762,6 @@ function joinRound(multiIndex: MultiIndex, providers: ProposalProvider[], prefix
   // if we never found a provider that means we have no more valid solutions
   // and we have nothing more to do
   if(bestProvider === undefined || bestProposal.cardinality === 0) {
-    if(bestProviderIx !== undefined) solverInfo[bestProviderIx]++;
     return;
   }
 


### PR DESCRIPTION
There is no point in checking the rest of proposal providers after a proposal with zero cardinality was returned.

I could have `return`ed directly instead of `break`ing the loop but wanted to keep an option of using the next `console.log` statement for debugging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/709)
<!-- Reviewable:end -->
