### PR TITLE
Lookup with missing variables

### DIFF
--- a/src/runtime/builder.ts
+++ b/src/runtime/builder.ts
@@ -299,6 +299,10 @@ function buildScans(block, context, scanLikes, outputScans) {
 
       if(!(entity || attribute || value || node)) {
         context.errors.push(errors.blankScan(block, scanLike));
+      } else {
+        entity = entity || context.createVariable();
+        attribute = attribute || context.createVariable();
+        value = value || context.createVariable();
       }
 
       let final = new join.Scan(scanLike.id + "|build", entity, attribute, value, node, scanLike.scopes);

--- a/src/runtime/join.ts
+++ b/src/runtime/join.ts
@@ -184,7 +184,7 @@ export class Scan {
     let solving = [];
     let solveNode = this.node !== undefined;
     let depth = solveNode ? 4 : 3;
-    this._fullScanLookup(index.eavIndex, solving, results, resolved, 0, 0, depth);
+    this._fullScanLookup(index.aveIndex, solving, results, [a,v,e,node], 0, 0, depth);
     return results;
   }
 
@@ -255,9 +255,9 @@ export class Scan {
         default:
           if(proposal.providing === undefined) {
             let providing = proposal.providing = [];
-            if(e === undefined) providing.push(this.e);
             if(a === undefined) providing.push(this.a);
             if(v === undefined) providing.push(this.v);
+            if(e === undefined) providing.push(this.e);
             if(node === undefined && this.node !== undefined) providing.push(this.node);
           }
           // full scan

--- a/test/join.ts
+++ b/test/join.ts
@@ -2056,6 +2056,70 @@ test("lookup with bound attribute", (assert) => {
   assert.end();
 })
 
+test("lookup with missing value", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "tag", "person"],
+      ["a", "name", "chris"],
+      ["b", "tag", "result"],
+      ["b", "record", "a"],
+      ["b", "attribute", "tag"],
+      ["c", "tag", "result"],
+      ["c", "record", "a"],
+      ["c", "attribute", "name"]
+    ],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    prepare data
+    ~~~
+      commit
+        [#person name: "chris"]
+    ~~~
+
+    test
+    ~~~
+      search
+        lookup[record attribute]
+        not(record.tag = "result")
+      commit
+        [#result record attribute]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("lookup with missing record and attribute", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "tag", "result"],
+      ["b", "tag", "person"],
+      ["b", "name", "chris"],
+      ["a", "value", "result"],
+      ["a", "value", "person"],
+      ["a", "value", "chris"]
+    ],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    prepare data
+    ~~~
+      commit
+        [#result]
+        [#person name: "chris"]
+    ~~~
+    test
+    ~~~
+      search
+        lookup[value]
+        result = [#result]
+      commit
+        result.value := value
+    ~~~
+  `);
+  assert.end();
+})
+
 test("lookup with free attribute, node and bound value", (assert) => {
   let expected = {
     insert: [


### PR DESCRIPTION
@ibdknox This is the simplest fix for lookup with missing variables (albeit not performant). Plus I've changed default index for full-scan to `ave`.

I haven't pushed any other full-scan optimizations since in this implementation missing variables won't trigger full-scan. But if full-scan will be used in other contexts (asides from `****`) then please tell me and I'll be glad to push an adaptive index support to full-scan.

Closes #685.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/715)
<!-- Reviewable:end -->
