### PR TITLE
Dot-notation for records

### DIFF
--- a/src/runtime/parser.ts
+++ b/src/runtime/parser.ts
@@ -377,7 +377,6 @@ export class Parser extends chev.Parser {
   attributeAccess: any;
   actionStatement: any;
   actionEqualityRecord: any;
-  actionAttributeExpression: any;
   actionOperation: any;
   actionLookup: any;
   variable: any;
@@ -651,7 +650,7 @@ export class Parser extends chev.Parser {
         }},
         {ALT: () => {
           let op = self.CONSUME2(Mutate);
-          let value: any = self.SUBRULE2(self.actionAttributeExpression, [op.image, parent]);
+          let value: any = self.SUBRULE2(self.expression, [op.image, parent]);
           if(value.type === "record" && !value.extraProjection) {
             value.extraProjection = [parent];
           }
@@ -711,13 +710,6 @@ export class Parser extends chev.Parser {
       self.block[self.currentAction](action);
       return action;
     });
-
-    self.RULE("actionAttributeExpression", (action, parent) => {
-      return self.OR([
-        {ALT: () => { return self.SUBRULE(self.record, [false, action, parent]); }},
-        {ALT: () => { return self.SUBRULE(self.infix); }},
-      ])
-    })
 
     self.RULE("actionEqualityRecord", () => {
       let variable = self.SUBRULE(self.variable);
@@ -1273,14 +1265,13 @@ export class Parser extends chev.Parser {
     // Expression
     //-----------------------------------------------------------
 
-    self.RULE("expression", () => {
-      let action;
+    self.RULE("expression", (action?, parent?) => {
       if(self.currentAction !== "match") {
-        action = "+=";
+        action = action || "+=";
       }
       return self.OR([
         {ALT: () => { return self.SUBRULE(self.infix); }},
-        {ALT: () => { return self.SUBRULE(self.record, [false, action]); }},
+        {ALT: () => { return self.SUBRULE(self.record, [false, action, parent]); }},
       ]);
     });
 

--- a/test/all.ts
+++ b/test/all.ts
@@ -2,3 +2,4 @@ import "./join";
 import "./eavs";
 import "./math";
 import "./strings";
+import "./syntax";

--- a/test/syntax.ts
+++ b/test/syntax.ts
@@ -1,0 +1,83 @@
+import * as test from "tape";
+import {evaluate} from "./shared_functions";
+
+test("dot-notation with a variable in a search", (assert) => {
+  let expected = {
+    insert: [["a", "tag", "foo"],
+             ["a", "value", 42],
+             ["b", "tag", "result"],
+             ["b", "value", 42]],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    prepare
+    ~~~
+      commit
+        [#foo value: 42]
+    ~~~
+
+    test
+    ~~~
+      search
+        foo = [#foo]
+        value = foo.value
+      commit
+        [#result value]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("dot-notation with a record in a search", (assert) => {
+  let expected = {
+    insert: [["a", "tag", "foo"],
+             ["a", "value", 42],
+             ["b", "tag", "result"],
+             ["b", "value", 42]],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    prepare
+    ~~~
+      commit
+        [#foo value: 42]
+    ~~~
+
+    test
+    ~~~
+      search
+        value = [#foo].value
+      commit
+        [#result value]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("double dot-notation in a search", (assert) => {
+  let expected = {
+    insert: [["a", "tag", "foo"],
+             ["a", "value", "b"],
+             ["b", "tag", "bar"],
+             ["b", "value", 42],
+             ["c", "tag", "result"],
+             ["c", "value", 42]],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    prepare
+    ~~~
+      commit
+        [#foo value: [#bar value: 42]]
+    ~~~
+
+    test
+    ~~~
+      search
+        value = [#foo].value.value
+      commit
+        [#result value]
+    ~~~
+  `);
+  assert.end();
+})


### PR DESCRIPTION
This PR adds support for code like `[#foo].tag` in a search section.

There is an issue that prevents it from working in an action section (scans should not generate proposals if a dependent variable is covered by some instance of `GenerateId` provider that hasn't been accepted yet), but I'll work on this in subsequent PR.

Let me know if there is anything you'd like me to change in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/722)
<!-- Reviewable:end -->
