### PR TITLE
enable source maps debugging

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "build",
     "target": "es5",
     "sourceMap": true,
+    "inlineSources": true,
     "skipDefaultLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "experimentalDecorators" : true


### PR DESCRIPTION
It was impossible to use source maps debugging (with breakpoints on .ts sources) on Chrome (55) until I've explicitly set inlineSources to true