### PR TITLE
Fix/horrible perf

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
       .__root.ide-root { order: 1; flex: 0 1 auto; }
       .__root.application-root { order: 2; flex: 1 1 auto; color: #555; }
       .application-container { display: flex; flex-direction: column; flex: 1; }
-      .program { position: relative; flex: 1; flex-direction: column; align-self: stretch; padding:20px; overflow: auto; margin-left:50px; display:flex; }
+      .program { position: relative; flex: 1; flex-direction: column; align-self: stretch; padding:20px; overflow: auto; display:flex; }
 
     </style>
 

--- a/src/ide.ts
+++ b/src/ide.ts
@@ -717,6 +717,9 @@ export class Editor {
   /** Whether the editor has changed since the last update. */
   dirty = false;
 
+  /** The current cached Markdown representation of the document. */
+  _md:string;
+
   /** Whether the editor is being externally updated with new content. */
   reloading = false;
 
@@ -797,6 +800,7 @@ export class Editor {
     this.reloading = false;
     this.history.transitioning = false;
     this.dirty = false;
+    this._md = undefined;
   }
 
   // This is an update to an existing document, so we need to figure out what got added and removed.
@@ -945,6 +949,8 @@ export class Editor {
   }
 
   toMarkdown() {
+    if(this._md) return this._md;
+
     let cm = this.cm;
     let doc = cm.getDoc();
     let spans = this.getAllSpans();
@@ -1022,7 +1028,8 @@ export class Editor {
       pieces.push(fullText.substring(pos));
     }
 
-    return pieces.join("");
+    this._md = pieces.join("");
+    return this._md;
   }
 
   refresh() {
@@ -1667,6 +1674,7 @@ export class Editor {
     }
     this.changingSpans = undefined;
     this.changing = false;
+    this._md = undefined;
     this.history.transitioning = false;
     this.formatting = {};
     this.queueUpdate();


### PR DESCRIPTION
This helps extend the size ceiling on documents in the editor temporarily by memoizing the function which contains the majority of the expensive calls. Since it's called in 2-3 separate occasions this improves performance enough to be workable again.

I'm currently stress-testing it to ensure there aren't situations where stale values may get used, but that shouldn't be possible so long as all doc changes flow through CMs change pipeline.

Slightly longer term, the right solution to this problem is either incremental parsing or dropping the text mapping phase and exchange something less expensive to compute.