### PR TITLE
add string find

### DIFF
--- a/src/runtime/providers/string.ts
+++ b/src/runtime/providers/string.ts
@@ -182,7 +182,6 @@ class Find extends Constraint {
     return text.indexOf(subtext, returns[0] - 1) === returns[0];
   }
 
-  // substring always returns cardinality 1
   getProposal(tripleIndex, proposed, prefix) {
     let proposal = this.proposalObject;
     let {args} = this.resolve(prefix);

--- a/src/runtime/providers/string.ts
+++ b/src/runtime/providers/string.ts
@@ -107,7 +107,6 @@ class Substring extends Constraint {
     let to = text.length;
     if (args[1] != undefined) from = args[1] - 1;
     if (args[2] != undefined) to = args[2];
-    console.log("test string", text.substring(from, to), from, to, returns[0]);
     return text.substring(from, to) === returns[0];
   }
 
@@ -124,6 +123,90 @@ class Substring extends Constraint {
     return proposal;
   }
 }
+
+class Find extends Constraint {
+  static AttributeMapping = {
+    "text": 0,
+    "subtext": 1,
+    "case-sensitive": 2,
+    "from": 3,
+  }
+  static ReturnMapping = {
+    "string-position": 0,
+    "result-index": 0,
+  }
+
+  returnType: "both" | "position";
+
+  constructor(id: string, args: any[], returns: any[]) {
+    super(id, args, returns);
+    if(this.returns[1] !== undefined && this.returns[0] !== undefined) {
+      this.returnType = "both"
+    } else if(this.returns[0] !== undefined) {
+      this.returnType = "position";
+    }
+  }
+
+  resolveProposal(proposal, prefix) {
+    return proposal.index;
+  }
+
+  getIndexes(text, subtext, from, caseSensitive, withIx) {
+    let start = from || 0;
+    let currentIndex;
+    let ixs = [];
+    let subLength = subtext.length;
+    if(!caseSensitive) {
+      text = text.toLowerCase();
+      subtext = subtext.toLowerCase();
+    }
+    if(withIx) {
+      while ((currentIndex = text.indexOf(subtext, start)) > -1) {
+        ixs.push([currentIndex + 1, ixs.length + 1]);
+        start = currentIndex + subLength;
+      }
+    } else {
+      while ((currentIndex = text.indexOf(subtext, start)) > -1) {
+        ixs.push(currentIndex + 1);
+        start = currentIndex + subLength;
+      }
+    }
+    return ixs;
+  }
+
+  test(prefix) {
+    let {args, returns} = this.resolve(prefix);
+    let text = args[Find.AttributeMapping["text"]];
+    let subtext = args[Find.AttributeMapping["subtext"]];
+    if(typeof text !== "string"|| typeof subtext !== "string") return false;
+    return text.indexOf(subtext, returns[0] - 1) === returns[0];
+  }
+
+  // substring always returns cardinality 1
+  getProposal(tripleIndex, proposed, prefix) {
+    let proposal = this.proposalObject;
+    let {args} = this.resolve(prefix);
+    let text = args[Find.AttributeMapping["text"]];
+    let subtext = args[Find.AttributeMapping["subtext"]];
+    let caseSensitive = args[Find.AttributeMapping["case-sensitive"]];
+    let from = args[Find.AttributeMapping["from"]];
+    if(typeof text !== "string"|| typeof subtext !== "string") {
+      proposal.cardinality = 0;
+      return;
+    }
+    let both = this.returnType === "both";
+    let indexes = this.getIndexes(text, subtext, from, caseSensitive, both);
+    if(both) {
+      proposal.providing = [this.returns[0], this.returns[1]];
+    } else {
+      proposal.providing = this.returns[0];
+    }
+    proposal.cardinality = indexes.length;
+    proposal.index = indexes;
+    return proposal;
+  }
+}
+
 
 class Convert extends Constraint {
   static AttributeMapping = {
@@ -345,5 +428,6 @@ providers.provide("substring", Substring);
 providers.provide("convert", Convert);
 providers.provide("urlencode", Urlencode);
 providers.provide("length", Length);
+providers.provide("find", Find);
 
 providers.provide("eve-internal/concat", InternalConcat);

--- a/src/runtime/providers/string.ts
+++ b/src/runtime/providers/string.ts
@@ -152,7 +152,7 @@ class Find extends Constraint {
   }
 
   getIndexes(text, subtext, from, caseSensitive, withIx) {
-    let start = from || 0;
+    let start = (from || 1) - 1;
     let currentIndex;
     let ixs = [];
     let subLength = subtext.length;

--- a/test/strings.ts
+++ b/test/strings.ts
@@ -14,11 +14,11 @@ test("test string join ordering", (assert) => {
                 ~~~
                 search
                   [#foo token level]
-                  index = sort[value:token given:token]                 
+                  index = sort[value:token given:token]
                   a = join[token index given:token with:"/"]
                   a = "a/naxxo/parg/zkp"
                   b = join[token index:level given:token with:"/"]
-                  b = "parg/naxxo/a/zkp"                  
+                  b = "parg/naxxo/a/zkp"
                 commit
                   [#success]
                 ~~~
@@ -77,7 +77,7 @@ test("test length equality", (assert) => {
     search
       len = length[text: "test"]
       len = 4
-      
+
     commit
       [len: len]
     ~~~
@@ -169,9 +169,98 @@ test("length of multi-byte characters as code-points", (assert) => {
     ~~~
     search
       len = length[text: "𝐁b" as: "code-points"]
-      
+
     commit
       [len: len]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("find occurrences in a string", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "at", "3"],
+      ["b", "at", "26"],
+      ["c", "at", "28"],
+      ["d", "at", "34"],
+    ],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    ~~~
+    search
+      at = find[text: "I learned to play the Ukulele in Lebanon.", subtext: "le"]
+
+    commit
+      [at]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("find occurrences in a string case sensitive", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "at", "3"],
+      ["b", "at", "26"],
+      ["c", "at", "28"],
+    ],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    ~~~
+    search
+      at = find[text: "I learned to play the Ukulele in Lebanon.", subtext: "le", case-sensitive: true]
+
+    commit
+      [at]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("find occurrences in a string with index", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "at", "3"],
+      ["a", "ix", "1"],
+      ["b", "at", "26"],
+      ["b", "ix", "2"],
+      ["c", "at", "28"],
+      ["c", "ix", "3"],
+    ],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    ~~~
+    search
+      (at, ix) = find[text: "I learned to play the Ukulele in Lebanon.", subtext: "le", case-sensitive: true]
+
+    commit
+      [at, ix]
+    ~~~
+  `);
+  assert.end();
+})
+
+test("find occurrences in a string with index and a starting position", (assert) => {
+  let expected = {
+    insert: [
+      ["b", "at", "26"],
+      ["b", "ix", "1"],
+      ["c", "at", "28"],
+      ["c", "ix", "2"],
+    ],
+    remove: []
+  };
+  evaluate(assert, expected, `
+    ~~~
+    search
+      (at, ix) = find[text: "I learned to play the Ukulele in Lebanon.", subtext: "le", case-sensitive: true, from: 20]
+
+    commit
+      [at, ix]
     ~~~
   `);
   assert.end();


### PR DESCRIPTION
adds a `find[]` method that takes the following arguments:

- *text*: the base text to look in
- *subtext*: the text we're looking for
- *from* (optional): an index to start from
- *case-sensitive* (optional): whether or not the search should take case into account (default false)

And returns:

- *string-position*: position of the subtext in the string
- *result-index*: the index of this position in the results (e.g. 1 is the first occurrence of subtext)