### PR TITLE
Fix #704 and #703

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -313,6 +313,10 @@ export class EveClient {
     onHashChange({});
   }
 
+  _css(data) {
+    document.getElementById("app-styles").innerHTML = data.css;
+  }
+
   _parse(data) {
     if(!this.showIDE) return;
     this.ide.loadDocument(data.generation, data.text, data.spans, data.extraInfo, data.css); // @FIXME

--- a/src/runtime/runtimeClient.ts
+++ b/src/runtime/runtimeClient.ts
@@ -33,6 +33,7 @@ export abstract class RuntimeClient {
     if(errors && errors.length) console.error(errors);
     results.code = code;
     this.lastParse = results;
+    this.send(JSON.stringify({type: "css", css: this.enabledCss()}));
     this.makeEvaluation();
     this.evaluation.fixpoint();
   }
@@ -98,7 +99,7 @@ export abstract class RuntimeClient {
   enabledCss() {
       var css = "";
       this.lastParse.code.replace(/(?:```|~~~)css\n([\w\W]*?)\n(?:```|~~~)/g, (g0, g1) => { // \n excludes disabled blocks
-        css += g1;
+        css += g1 + "\n";
       });
 
       // remove whitespace before open braces, and add a newline after open brace


### PR DESCRIPTION
This makes it so that we load CSS when we load a program and also fixes the issue where CSS blocks aren't appropriately separated by a newline when they're concatenated together.

Fixes #704 and #703.