### PR TITLE
Error detection when a just created record is being accessed

### DIFF
--- a/src/runtime/builder.ts
+++ b/src/runtime/builder.ts
@@ -297,6 +297,15 @@ function buildScans(block, context, scanLikes, outputScans) {
         context.provide(node);
       }
 
+      for (let action of (block.commits.concat(block.binds))) {
+        if (action.type === "record" &&
+            context.getValue(action.variable) === entity &&
+            action.action !== "<-") {
+          context.errors.push(errors.scanWithNotYetCreatedEntity(block, scanLike));
+          return;
+        }
+      }
+
       if(!(entity || attribute || value || node)) {
         context.errors.push(errors.blankScan(block, scanLike));
       } else {

--- a/src/runtime/errors.ts
+++ b/src/runtime/errors.ts
@@ -204,6 +204,12 @@ export function blankScan(block, scan) {
   return new EveError(id, start, stop, messages.blankScan());
 }
 
+export function scanWithNotYetCreatedEntity(block, scan) {
+  let {id, start: blockStart} = block;
+  let [start, stop] = parser.nodeToBoundaries(scan, blockStart);
+  return new EveError(id, start, stop, messages.notYetCreatedEntity());
+}
+
 export function invalidLookupAction(block, action) {
   let {id, start: blockStart} = block;
   let [start, stop] = parser.nodeToBoundaries(action, blockStart);
@@ -262,6 +268,8 @@ export var messages = {
   unprovidedVariable: (varName) => `Nothing is providing a value for ${varName}`,
 
   unimplementedExpression: (op) => `There's no definition for the function ${op}`,
+
+  notYetCreatedEntity: () => "The record can't be searched in the same instant it's been created",
 
   blankScan: () => 'Lookup requires at least one attribute: record, attribute, value, or node',
   invalidLookupAction: (missing) => `Updating a lookup requires that record, attribute, and value all be provided. Looks like ${missing.join("and")} is missing.`,

--- a/src/runtime/parser.ts
+++ b/src/runtime/parser.ts
@@ -622,7 +622,6 @@ export class Parser extends chev.Parser {
           self.block.scan(scan);
           self.CONSUME(Merge);
           let record = self.SUBRULE(self.record, [true, actionKey, "+=", undefined, variable]) as any;
-          record.variable = variable;
           record.action = "<-";
           return record;
         }},
@@ -679,7 +678,6 @@ export class Parser extends chev.Parser {
         {ALT: () => {
           self.CONSUME(Merge);
           let record = self.SUBRULE(self.record, [true, actionKey, "+=", undefined, variable]) as any;
-          record.needsEntity = true;
           record.action = "<-";
           return record;
         }},

--- a/test/all.ts
+++ b/test/all.ts
@@ -2,3 +2,4 @@ import "./join";
 import "./eavs";
 import "./math";
 import "./strings";
+import "./errors";

--- a/test/errors.ts
+++ b/test/errors.ts
@@ -1,0 +1,61 @@
+import * as test from "tape";
+import {evaluate} from "./shared_functions";
+
+test("errors when using an attribute of just created record as a value", (assert) => {
+  let expected = {
+    insert: [["a", "tag", "foo"]],
+    remove: [],
+    errors: true
+  };
+  evaluate(assert, expected, `
+    prepare
+    ~~~
+      commit
+        [#foo]
+    ~~~
+
+    test
+    ~~~
+      search
+        foo = [#foo]
+      commit
+        bar = [#bar]
+        foo.copy-of-bar-tag += bar.tag
+    ~~~
+  `);
+  assert.end();
+})
+
+test("errors when changing a sub-record of just created record", (assert) => {
+  let expected = {
+    insert: [],
+    remove: [],
+    errors: true
+  };
+  evaluate(assert, expected, `
+    test
+    ~~~
+      commit
+        baz = [#baz bar: [#bar]]
+        baz.bar.tag := "new bar"
+    ~~~
+  `);
+  assert.end();
+})
+
+test("errors when changing a sub-record of just created record using a tag shortcut syntax", (assert) => {
+  let expected = {
+    insert: [],
+    remove: [],
+    errors: true
+  };
+  evaluate(assert, expected, `
+    test
+    ~~~
+      commit
+        baz = [#baz bar: [#bar]]
+        baz.bar += #child
+    ~~~
+  `);
+  assert.end();
+})


### PR DESCRIPTION
It'll be easier to show the result:

![](http://i.imgur.com/MvGHJHq.png)

Compared to current behavior (silent failure): http://play.witheve.com/#gist:ec1ef78e3b2e54d5cdab32604069e236-examples-untitled.eve

Suggestions are appreciated to improve the text of error :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/740)
<!-- Reviewable:end -->
