### PR TITLE
Fix + should not concat strings

### DIFF
--- a/examples/gaussian.eve
+++ b/examples/gaussian.eve
@@ -28,7 +28,7 @@ For each click, generate a gaussian sample, use floor to bin it into histogram b
 ~~~
 search @event @session
   e = [#click]
-  x = floor[value: gaussian[seed: e, σ: 10, μ: 25]]
+  x = floor[value: gaussian[seed: e, stdev: 10, mean: 25]]
   total = if [#slots x total] then total + 1 else 1
 
 commit

--- a/src/runtime/providers/math.ts
+++ b/src/runtime/providers/math.ts
@@ -65,13 +65,15 @@ function degreesToRadians(degrees:number){
 }
 
 class Add extends TotalFunctionConstraint {
-  resolveProposal(proposal, prefix) {
-    let {args} = this.resolve(prefix);
-    return [this.getReturnValue(args)];
-  }
-
   getReturnValue(args) {
-    return args[0] + args[1];
+    let a = parseFloat(args[0]);
+    let b = parseFloat(args[1]);
+    
+    if ((!isNaN(a)) && (!isNaN(b))) {
+    return a + b;
+    } else {
+      return NaN
+    }
   }
 }
 

--- a/src/runtime/providers/math.ts
+++ b/src/runtime/providers/math.ts
@@ -300,8 +300,8 @@ class Random extends TotalFunctionConstraint {
 class Gaussian extends TotalFunctionConstraint {
   static AttributeMapping = {
     "seed": 0,
-    "σ": 1,
-    "μ": 2
+    "stdev": 1,
+    "mean": 2
   }
 
   static cache = {};

--- a/src/runtime/providers/math.ts
+++ b/src/runtime/providers/math.ts
@@ -66,11 +66,8 @@ function degreesToRadians(degrees:number){
 
 class Add extends TotalFunctionConstraint {
   getReturnValue(args) {
-    let a = parseFloat(args[0]);
-    let b = parseFloat(args[1]);
-    
-    if ((!isNaN(a)) && (!isNaN(b))) {
-    return a + b;
+    if ((typeof(args[0]) === "number") && (typeof(args[1]) === "number")) {
+      return args[0] + args[1];
     } else {
       return NaN
     }

--- a/test/math.ts
+++ b/test/math.ts
@@ -365,9 +365,9 @@ test("Test gaussian seed", (assert) => {
   evaluate(assert, expected, `
     ~~~
     search
-      g1 = gaussian[seed:0, σ:1.0, µ:0.0]
-      g2 = gaussian[seed:0, σ:1.0, µ:0.0]
-      g3 = gaussian[seed:1, σ:1.0, µ:0.0]
+      g1 = gaussian[seed:0, stdev:1.0, mean:0.0]
+      g2 = gaussian[seed:0, stdev:1.0, mean:0.0]
+      g3 = gaussian[seed:1, stdev:1.0, mean:0.0]
       same-seed = if g1 = g2 then "true" else "false"
       different-seed = if g1 = g3 then "true" else "false"
 

--- a/test/math.ts
+++ b/test/math.ts
@@ -228,10 +228,9 @@ let Fix_list : valueTest[]  = [
 testSingleExpressionByList(Fix_list );
 
 
-test("Test that string concatenation is still working after NaN change.", (assert) => {
+test("Test that string concatenation with plus does not work.", (assert) => {
   let expected = {
     insert: [
-      ["a", "result", "Test Testy"],
     ],
     remove: [],
   };
@@ -241,6 +240,95 @@ test("Test that string concatenation is still working after NaN change.", (asser
     search
       a = "Test "
       b = "Testy"
+      x =  a + b
+
+    bind
+      [result: x]
+    ~~~
+  `);
+  assert.end();
+});
+
+test("Test that that plus with string numbers does work.", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "result", "2"],
+    ],
+    remove: [],
+  };
+
+  evaluate(assert, expected, `
+    ~~~
+    search
+      a = "1"
+      b = "1"
+      x =  a + b
+
+    bind
+      [result: x]
+    ~~~
+  `);
+  assert.end();
+});
+
+test("Test that plus with string + number does work.", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "result", "2"],
+    ],
+    remove: [],
+  };
+
+  evaluate(assert, expected, `
+    ~~~
+    search
+      a = "1"
+      b = 1
+      x =  a + b
+
+    bind
+      [result: x]
+    ~~~
+  `);
+  assert.end();
+});
+
+test("Test that plus with number + string does work.", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "result", "2"],
+    ],
+    remove: [],
+  };
+
+  evaluate(assert, expected, `
+    ~~~
+    search
+      a = 1
+      b = "1"
+      x =  a + b
+
+    bind
+      [result: x]
+    ~~~
+  `);
+  assert.end();
+});
+
+
+test("Test that that plus with number + number does work.", (assert) => {
+  let expected = {
+    insert: [
+      ["a", "result", "2"],
+    ],
+    remove: [],
+  };
+
+  evaluate(assert, expected, `
+    ~~~
+    search
+      a = 1
+      b = "1"
       x =  a + b
 
     bind

--- a/test/math.ts
+++ b/test/math.ts
@@ -249,10 +249,9 @@ test("Test that string concatenation with plus does not work.", (assert) => {
   assert.end();
 });
 
-test("Test that that plus with string numbers does work.", (assert) => {
+test("Test that that plus with string numbers filters.", (assert) => {
   let expected = {
     insert: [
-      ["a", "result", "2"],
     ],
     remove: [],
   };
@@ -271,10 +270,9 @@ test("Test that that plus with string numbers does work.", (assert) => {
   assert.end();
 });
 
-test("Test that plus with string + number does work.", (assert) => {
+test("Test that plus with string + number filters.", (assert) => {
   let expected = {
     insert: [
-      ["a", "result", "2"],
     ],
     remove: [],
   };
@@ -293,10 +291,9 @@ test("Test that plus with string + number does work.", (assert) => {
   assert.end();
 });
 
-test("Test that plus with number + string does work.", (assert) => {
+test("Test that plus with number + string filters..", (assert) => {
   let expected = {
     insert: [
-      ["a", "result", "2"],
     ],
     remove: [],
   };
@@ -328,7 +325,7 @@ test("Test that that plus with number + number does work.", (assert) => {
     ~~~
     search
       a = 1
-      b = "1"
+      b = 1
       x =  a + b
 
     bind


### PR DESCRIPTION
For https://github.com/witheve/Eve/issues/631 finally.

I've gone for the more conservative option of only filtering if one or both items cannot be converted to a number. 

Let me know if you want this code to filter and I'll change

search
a = "1"
b = "2"
x = a + b
commit @browser
[#div text:x]

Which will currently set x to 3.