### PR TITLE
Fix a required typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mkdirp": "^0.5.1",
     "node-uuid": "^1.4.7",
     "request": "^2.75.0",
-    "typescript": "^2.0.3",
+    "typescript": "^2.1.4",
     "ws": "^1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
`keyof` type is supported only since typescript 2.1
(but reliably compiles runtime.ts only since 2.1.4)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/747)
<!-- Reviewable:end -->
