### PR TITLE
Refactor runtime functions

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -2,6 +2,7 @@
 // Runtime
 //------------------------------------------------------------------------
 
+type RawValue = string|number;
 type ID = number;
 type Multiplicity = number;
 
@@ -13,7 +14,7 @@ function createArray() {
   return [];
 }
 
-function isNumber(thing:any) {
+function isNumber(thing:any): thing is number {
   return typeof thing === "number";
 }
 
@@ -24,7 +25,7 @@ function isNumber(thing:any) {
 export class Interner {
   strings: {[value:string]: ID|undefined} = createHash();
   numbers: {[value:number]: ID|undefined} = createHash();
-  IDs: (string|number)[] = createArray();
+  IDs: RawValue[] = createArray();
   IDRefCount: number[] = createArray();
   IDFreeList: number[] = createArray();
   ix: number = 0;
@@ -33,7 +34,7 @@ export class Interner {
     return this.IDFreeList.pop() || this.ix++;
   }
 
-  intern(value: (string|number)): ID {
+  intern(value: RawValue): ID {
     let coll;
     if(isNumber(value)) {
       coll = this.numbers;
@@ -52,7 +53,7 @@ export class Interner {
     return found;
   }
 
-  get(value: (string|number)): ID|undefined {
+  get(value: RawValue): ID|undefined {
     let coll;
     if(isNumber(value)) {
       coll = this.numbers;
@@ -62,7 +63,7 @@ export class Interner {
     return coll[value];
   }
 
-  reverse(id: ID): (string|number) {
+  reverse(id: ID): RawValue {
     return this.IDs[id];
   }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -488,6 +488,7 @@ abstract class FunctionConstraint implements Constraint {
   apply: (... things: any[]) => undefined|(number|string)[]; // @FIXME: Not supporting multi-return yet.
   estimate?:(index:Index, prefix:ID[], transaction:number, round:number) => number
 
+  fieldNames:string[];
   proposal:Proposal = {cardinality:0, forFields: createArray(), forRegisters: createArray(), proposer: this};
   protected resolved:ResolvedFields = {};
   protected registers:Register[] = createArray();
@@ -495,7 +496,9 @@ abstract class FunctionConstraint implements Constraint {
   protected applyInputs:RawValue[] = createArray();
 
   setup() {
-    for(let fieldName of Object.keys(this.fields)) {
+    this.fieldNames = Object.keys(this.fields);
+
+    for(let fieldName of this.fieldNames) {
       let field = this.fields[fieldName];
       if(isRegister(field)) this.registers.push(field);
     }
@@ -514,7 +517,7 @@ abstract class FunctionConstraint implements Constraint {
   resolve(prefix:ID[]) {
     let resolved = this.resolved;
 
-    for(let fieldName of Object.keys(this.fields)) {
+    for(let fieldName of this.fieldNames) {
       let field = this.fields[fieldName];
       if(isRegister(field)) {
         resolved[fieldName] = prefix[field.offset];

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -490,9 +490,9 @@ abstract class FunctionConstraint implements Constraint {
 
   proposal:Proposal = {cardinality:0, forFields: createArray(), forRegisters: createArray(), proposer: this};
   protected resolved:ResolvedFields = {};
-  protected registers:Register[] = [];
-  protected registerLookup:boolean[] = [];
-  protected applyInputs:RawValue[] = [];
+  protected registers:Register[] = createArray();
+  protected registerLookup:boolean[] = createArray();
+  protected applyInputs:RawValue[] = createArray();
 
   setup() {
     for(let fieldName of Object.keys(this.fields)) {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -462,9 +462,9 @@ interface Constraint {
 type ConstraintFieldMap = {[name:string]: ScanField};
 type ResolvedFields = {[fieldName:string]: ResolvedValue};
 
-abstract class FunctionConstraint implements Constraint {
-  static registered: {[name:string]: typeof FunctionConstraintInstance} = {};
-  static register(name:string, klass: typeof FunctionConstraintInstance) {
+class FunctionConstraint implements Constraint {
+  static registered: {[name:string]: typeof FunctionConstraint} = {};
+  static register(name:string, klass: typeof FunctionConstraint) {
     FunctionConstraint.registered[name] = klass;
   }
 
@@ -674,12 +674,6 @@ abstract class FunctionConstraint implements Constraint {
     // @TODO: Implement the logic for sorting function constraints or re-accepting after scan constraints to ensure prefix is filled.
     // @NOTE: Can we be smarter than solving for all registers here?
     return this.accept(index, prefix, transaction, round, this.registers);
-  }
-}
-
-class FunctionConstraintInstance extends FunctionConstraint {
-  constructor(fields:ConstraintFieldMap) {
-    super(fields);
   }
 }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -767,18 +767,33 @@ class Transaction {
 // Testing logic
 //------------------------------------------------------------------------------
 
+type RawEAVN = [RawValue, RawValue, RawValue, RawValue];
+type RawEAVNC = [RawValue, RawValue, RawValue, RawValue, number];
+
+let _currentTransaction = 0;
+function createChangeSet(...eavns:(RawEAVN|RawEAVNC)[]) {
+  let changes:ChangeSet = [];
+  for(let [e, a, v, n, c = 1] of eavns as RawEAVNC[]) {
+    changes.push(Change.fromValues(e, a, v, n, _currentTransaction, 0, c));
+  }
+  _currentTransaction++;
+
+  return changes;
+}
+
 // We'll accumulate the current program state here as we stream in changes.
 let currentState:ChangeSet = [];
 
 // A list of changesets to stream into the program. Each changeset corresponds to an input event.
-let changes:ChangeSet[] = [
-  [Change.fromValues("<1>", "tag", "person", 1, 0, 0, 1)],
-  [Change.fromValues("<1>", "name", "RAB", 1, 1, 0, 1)],
-  [Change.fromValues("<2>", "tag", "person", 1, 2, 0, 1), Change.fromValues("<2>", "name", "KERY", 1, 2, 0, 1)],
-  [Change.fromValues("<3>", "tag", "dog", 1, 3, 0, 1), Change.fromValues("<3>", "name", "jeff", 1, 3, 0, 1)],
-  [Change.fromValues("<4>", "name", "BORSCHT", 1, 4, 0, 1)],
-  [Change.fromValues("<4>", "tag", "person", 1, 5, 0, 1)],
-];
+let changes:ChangeSet[] = [];
+changes.push(
+  createChangeSet(["<1>", "tag", "person", 1]),
+  createChangeSet(["<1>", "name", "RAB", 1]),
+  createChangeSet(["<1>", "age", 7, 1]),
+  createChangeSet(["<2>", "tag", "person", 1], ["<2>", "name", "KERY", 1], ["<2>", "age", 41, 1]),
+  createChangeSet(["<3>", "tag", "dog", 1], ["<3>", "name", "jeff", 1], ["<3>", "age", 3, 1]),
+  createChangeSet(["<4>", "name", "BORSCHT", 1], ["<4>", "tag", "person", 1]),
+);
 
 // Manually created registers for the testing program below.
 let eReg = new Register(1);

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -647,7 +647,7 @@ abstract class FunctionConstraint implements Constraint {
     // @FIXME: We only support single-return atm.
     let outputs = this.unpackOutputs(this.apply.apply(this, inputs));
     if(!outputs) {
-      console.log("    * accepting", this.name, resolved, false);
+      console.log("    * accepting", this.name, resolved, inputs, false);
       return false;
     }
 
@@ -659,14 +659,14 @@ abstract class FunctionConstraint implements Constraint {
       let field = this.fields[returnName];
       if(isRegister(field) && resolved[returnName]) {
         if(resolved[returnName] !== outputs[ix]) {
-          console.log("    * accepting", this.name, resolved, false);
+          console.log("    * accepting", this.name, resolved, inputs, false);
           return false;
         }
       }
       ix++;
     }
 
-    console.log("    * accepting", this.name, resolved, true);
+    console.log("    * accepting", this.name, resolved, inputs, true);
     return true;
   }
 
@@ -750,6 +750,7 @@ class JoinNode implements Node {
   registerLength = 0;
   registerArrays:ID[][] = createArray();
   emptyProposal:Proposal = {cardinality: Infinity, forFields: [], forRegisters: [], skip: true, proposer: {} as Constraint};
+  inputState = {constraintIx: 0, state: ApplyInputState.none}
 
   constructor(public constraints:Constraint[]) {
     // We need to find all the registers contained in our scans so that
@@ -766,13 +767,31 @@ class JoinNode implements Node {
   }
 
   applyInput(input:Change, prefix:ID[]) {
-    let handled = ApplyInputState.none;
-    for(let constraint of this.constraints) {
-      let result = constraint.applyInput(input, prefix);
-      if(result === ApplyInputState.fail) return ApplyInputState.fail;
-      else if(result === ApplyInputState.pass) handled = ApplyInputState.pass;
+    let {inputState, constraints} = this;
+    inputState.state = ApplyInputState.none;
+    let ix = inputState.constraintIx;
+    // if we're not starting at the first constraint, that means we've applied
+    // one already, we need to unapply it in order to make sure things work out
+    if(ix !== 0) {
+      let prevConstraint = constraints[ix - 1];
+      for(let register of prevConstraint.getRegisters()) {
+        prefix[register.offset] = undefined;
+      }
     }
-    return handled;
+    for(let len = constraints.length; ix < len; ix++) {
+      let constraint = constraints[ix];
+      let result = constraint.applyInput(input, prefix);
+      if(result === ApplyInputState.fail) {
+        inputState.state = ApplyInputState.fail;
+        break;
+      }
+      else if(result === ApplyInputState.pass) {
+        inputState.state = ApplyInputState.pass;
+        break;
+      }
+    }
+    inputState.constraintIx = ix + 1;
+    return inputState;
   }
 
   presolveCheck(index:Index, input:Change, prefix:ID[], transaction:number, round:number):boolean {
@@ -808,7 +827,10 @@ class JoinNode implements Node {
       return results;
     }
 
-    let {forRegisters, proposer} = bestProposal;
+    let {proposer} = bestProposal;
+    // We have to slice here because we need to keep a reference to this even if later
+    // rounds might overwrite the proposal
+    let forRegisters = bestProposal.forRegisters.slice();
     let resolved = proposer.resolveProposal(index, prefix, bestProposal, transaction, round, proposedResults);
     resultLoop: for(let result of resolved) {
       let ix = 0;
@@ -839,33 +861,44 @@ class JoinNode implements Node {
   }
 
   exec(index:Index, input:Change, prefix:ID[], transaction:number, round:number, results:ID[][] = createArray()):boolean {
-    let ok = this.applyInput(input, prefix);
-    let countOfSolved = 0;
-    for(let elem of prefix) {
-      if(elem !== undefined) countOfSolved++;
+    let didSomething = false;
+    this.inputState.constraintIx = 0;
+    // we need to apply input for each constraint individually and then run genericJoin to
+    // see if it produces any output. This handles the case where a single input might apply
+    // to several constraints in the block and we need to make sure we cover every permutation.
+    // @TODO: handle the case where all the constraints have applied a change.
+    this.applyInput(input, prefix);
+    let ok = this.inputState.state;
+    let ix = this.inputState.constraintIx;
+    let foo = 0;
+    while(ix < this.constraints.length) {
+      if(ok === ApplyInputState.pass) {
+        let countOfSolved = 0;
+        for(let elem of prefix) {
+          if(elem !== undefined) countOfSolved++;
+        }
+        let remainingToSolve = this.registerLength - countOfSolved;
+        let valid = this.presolveCheck(index, input, prefix, transaction, round);
+        if(!valid) {
+          // do nothing
+        } else if(!remainingToSolve) {
+          // if it is valid and there's nothing left to solve, then we've found
+          // a full result and we should just continue
+          results.push(prefix.slice());
+          didSomething = true;
+        } else {
+          // For each node, find the new results that match the prefix.
+          this.genericJoin(index, prefix, transaction, round, results, remainingToSolve);
+          didSomething = true;
+        }
+      }
+      this.applyInput(input, prefix);
+      ok = this.inputState.state;
+      ix = this.inputState.constraintIx;
     }
-    let remainingToSolve = this.registerLength - countOfSolved;
-    let valid = this.presolveCheck(index, input, prefix, transaction, round);
-    if(!valid) {
-      return false;
-    } else if(!remainingToSolve) {
-      // if it is valid and there's nothing left to solve, then we've found
-      // a full result and we chould just continue
-      results.push(prefix.slice());
-      return true;
-    }
-
-    if(ok === ApplyInputState.fail) {
-      return false;
-    } else if(ok === ApplyInputState.pass && remainingToSolve) {
-      // For each node, find the new results that match the prefix.
-      this.genericJoin(index, prefix, transaction, round, results, remainingToSolve);
-      return true;
-    } else {
-      // If there is no affected prefix then tautologically there is no affected result, so we skip execution.
-      return true;
-    }
+    return didSomething;
   }
+
 }
 
 class InsertNode implements Node {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -647,7 +647,6 @@ abstract class FunctionConstraint implements Constraint {
     // @FIXME: We only support single-return atm.
     let outputs = this.unpackOutputs(this.apply.apply(this, inputs));
     if(!outputs) {
-      console.log("    * accepting", this.name, resolved, inputs, false);
       return false;
     }
 
@@ -659,14 +658,12 @@ abstract class FunctionConstraint implements Constraint {
       let field = this.fields[returnName];
       if(isRegister(field) && resolved[returnName]) {
         if(resolved[returnName] !== outputs[ix]) {
-          console.log("    * accepting", this.name, resolved, inputs, false);
           return false;
         }
       }
       ix++;
     }
 
-    console.log("    * accepting", this.name, resolved, inputs, true);
     return true;
   }
 

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -775,7 +775,7 @@ class JoinNode implements Node {
     if(ix !== 0) {
       let prevConstraint = constraints[ix - 1];
       for(let register of prevConstraint.getRegisters()) {
-        prefix[register.offset] = undefined;
+        prefix[register.offset] = undefined as any;
       }
     }
     for(let len = constraints.length; ix < len; ix++) {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -635,6 +635,16 @@ class FunctionConstraint implements Constraint {
   }
 
   accept(index:Index, prefix:ID[], transaction:number, round:number, solvingFor:Register[]):boolean {
+    // If none of the registers we're solving for intersect our inputs or outputs, we're not relevant to the solution.
+    let isRelevant = false;
+    for(let register of solvingFor) {
+      if(this.registerLookup[register.offset]) {
+        isRelevant = true;
+        break;
+      }
+    }
+    if(!isRelevant) return true;
+
     let resolved = this.resolve(prefix);
 
     // If we're missing an argument, we can't run yet so we preliminarily accept.

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -874,7 +874,6 @@ class JoinNode implements Node {
     this.applyInput(input, prefix);
     let ok = this.inputState.state;
     let ix = this.inputState.constraintIx;
-    let foo = 0;
     while(ix < this.constraints.length) {
       if(ok === ApplyInputState.pass) {
         let countOfSolved = 0;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -463,16 +463,16 @@ type ConstraintFieldMap = {[name:string]: ScanField};
 type ResolvedFields = {[fieldName:string]: ResolvedValue};
 
 abstract class FunctionConstraint implements Constraint {
-  static registered: {[name:string]: new (args:ConstraintFieldMap, returns:ConstraintFieldMap) => FunctionConstraint} = {};
-  static register(name:string, klass: new (args:ConstraintFieldMap, returns:ConstraintFieldMap) => FunctionConstraint) {
+  static registered: {[name:string]: typeof FunctionConstraintInstance} = {};
+  static register(name:string, klass: typeof FunctionConstraintInstance) {
     FunctionConstraint.registered[name] = klass;
   }
 
-  static create(name:string, args:ConstraintFieldMap, returns:ConstraintFieldMap):FunctionConstraint|undefined {
+  // @FIXME: This whole setup is a little weird.
+  static create(name:string, fields:ConstraintFieldMap):FunctionConstraint|undefined {
     let cur = FunctionConstraint.registered[name];
     if(!cur) return;
-    let created = new cur(args, returns);
-    created.setup();
+    let created = new cur(fields);
     return created;
   }
 
@@ -495,7 +495,6 @@ abstract class FunctionConstraint implements Constraint {
   protected applyInputs:RawValue[] = [];
 
   setup() {
-    console.log(this.args);
     for(let fieldName of Object.keys(this.fields)) {
       let field = this.fields[fieldName];
       if(isRegister(field)) this.registers.push(field);
@@ -504,6 +503,8 @@ abstract class FunctionConstraint implements Constraint {
     for(let register of this.registers) {
       this.registerLookup[register.offset] = true;
     }
+
+    if(this.name === "+") console.log(this.name, this.registers);
   }
 
   getRegisters() {
@@ -536,6 +537,7 @@ abstract class FunctionConstraint implements Constraint {
   // @TODO: fill this in
   propose(index:Index, prefix:ID[], transaction:number, round:number, results:any[]):Proposal {
     let proposal = this.proposal;
+    proposal.forRegisters.length = 0;
     let resolved = this.resolve(prefix);
 
     // If none of our returns are unbound
@@ -544,11 +546,13 @@ abstract class FunctionConstraint implements Constraint {
     for(let output of this.returnNames) {
       if(resolved[output] === undefined) {
         unresolvedOutput = true;
-        break;
+        let field = this.fields[output];
+        if(isRegister(field)) {
+          proposal.forRegisters.push(field);
+        }
       }
     }
     if(!unresolvedOutput) {
-      console.log("    * skip: resolved all outputs", prefix);
       proposal.skip = true;
       return proposal;
     }
@@ -558,7 +562,6 @@ abstract class FunctionConstraint implements Constraint {
     // co-inhabit the args object.
     for(let input of this.argNames) {
       if(resolved[input] === undefined) {
-        console.log("    * skip: unresolved input", prefix);
         proposal.skip = true;
         return proposal;
       }
@@ -613,13 +616,13 @@ abstract class FunctionConstraint implements Constraint {
     if(!outputs) return results;
 
     // Finally, if we had results, we create the result prefixes and pass them along.
-    let result = prefix.slice() as ID[];
+    let result = createArray() as ID[];
 
     let ix = 0;
     for(let returnName of this.returnNames) {
       let field = this.fields[returnName];
       if(isRegister(field) && !resolved[returnName]) {
-        result[field.offset] = outputs[ix];
+        result[ix] = outputs[ix];
       }
       ix++;
     }
@@ -635,8 +638,6 @@ abstract class FunctionConstraint implements Constraint {
     for(let argName of this.argNames) {
       if(resolved[argName] === undefined) return true;
     }
-
-
 
     // First we build the args array to provide the apply function.
     let inputs = this.packInputs(resolved);
@@ -676,6 +677,12 @@ abstract class FunctionConstraint implements Constraint {
   }
 }
 
+class FunctionConstraintInstance extends FunctionConstraint {
+  constructor(fields:ConstraintFieldMap) {
+    super(fields);
+  }
+}
+
 interface FunctionSetup {
   name:string,
   args:{[argName:string]: string},
@@ -712,6 +719,15 @@ makeFunction({
   returns: {},
   apply: (a:number, b:number) => {
     return (a === b) ? [] : undefined;
+  }
+});
+
+makeFunction({
+  name: "+",
+  args: {a: "number", b: "number"},
+  returns: {result: "number"},
+  apply: (a:number, b:number) => {
+    return [a + b];
   }
 });
 
@@ -787,7 +803,6 @@ class JoinNode implements Node {
         bestProposal = current;
       }
     }
-
 
     if(bestProposal.skip) {
       return results;
@@ -896,7 +911,6 @@ class Block {
     // results affected by it.
     for(let node of this.nodes) {
       for(let prefix of this.results) {
-        //console.log("P", prefix);
         let valid = node.exec(index, input, prefix, transaction, round, this.nextResults, changes);
         if(!valid) {
           return false;
@@ -978,6 +992,7 @@ let p1Reg = new Register(0);
 let p2Reg = new Register(1);
 let age1Reg = new Register(2);
 let age2Reg = new Register(3);
+let resultReg = new Register(4);
 
 // Test program. It evaluates:
 // search
@@ -985,31 +1000,41 @@ let age2Reg = new Register(3);
 // bind
 //   [#div | text: name]
 let blocks:Block[] = [
-  // new Block("things are happening", [
-  //   new JoinNode([
-  //     new Scan(eReg, GlobalInterner.intern("tag"), GlobalInterner.intern("person"), null),
-  //     new Scan(eReg, GlobalInterner.intern("name"), nameReg, null),
-  //   ]),
-  //   new InsertNode(GlobalInterner.intern("floopy div"), GlobalInterner.intern("tag"), GlobalInterner.intern("div"), GlobalInterner.intern(2)),
-  //   new InsertNode(GlobalInterner.intern("floopy div"), GlobalInterner.intern("text"), nameReg, GlobalInterner.intern(2)),
-  // ]),
+  new Block("things are happening", [
+    new JoinNode([
+      new Scan(eReg, GlobalInterner.intern("tag"), GlobalInterner.intern("person"), null),
+      new Scan(eReg, GlobalInterner.intern("name"), nameReg, null),
+    ]),
+    new InsertNode(GlobalInterner.intern("floopy div"), GlobalInterner.intern("tag"), GlobalInterner.intern("div"), GlobalInterner.intern(2)),
+    new InsertNode(GlobalInterner.intern("floopy div"), GlobalInterner.intern("text"), nameReg, GlobalInterner.intern(2)),
+  ]),
   new Block("> filters are cool", [
     new JoinNode([
       new Scan(p1Reg, GlobalInterner.intern("age"), age1Reg, null),
       new Scan(p2Reg, GlobalInterner.intern("age"), age2Reg, null),
-      FunctionConstraint.create(">", {a: age1Reg, b: age2Reg}, {})!
+      FunctionConstraint.create(">", {a: age1Reg, b: age2Reg})!
     ]),
-    new InsertNode(GlobalInterner.intern("doory-hoo"), GlobalInterner.intern("age1"), age1Reg, GlobalInterner.intern(76)),
-    new InsertNode(GlobalInterner.intern("doory-hoo"), GlobalInterner.intern("age2"), age2Reg, GlobalInterner.intern(77)),
+    new InsertNode(GlobalInterner.intern("is-greater-than"), GlobalInterner.intern("age1"), age1Reg, GlobalInterner.intern(76)),
+    new InsertNode(GlobalInterner.intern("is-greater-than"), GlobalInterner.intern("age2"), age2Reg, GlobalInterner.intern(76)),
   ]),
   new Block("= filters are cool", [
     new JoinNode([
       new Scan(p1Reg, GlobalInterner.intern("age"), age1Reg, null),
       new Scan(p2Reg, GlobalInterner.intern("age"), age2Reg, null),
-      FunctionConstraint.create("=", {a: age1Reg, b: age2Reg}, {})!
+      FunctionConstraint.create("=", {a: age1Reg, b: age2Reg})!
     ]),
-    new InsertNode(GlobalInterner.intern("equals-bibimbop"), GlobalInterner.intern("age1"), age1Reg, GlobalInterner.intern(76)),
-    new InsertNode(GlobalInterner.intern("equals-bibimbop"), GlobalInterner.intern("age2"), age2Reg, GlobalInterner.intern(77)),
+    new InsertNode(GlobalInterner.intern("is-equal"), GlobalInterner.intern("age1"), age1Reg, GlobalInterner.intern(76)),
+    new InsertNode(GlobalInterner.intern("is-equal"), GlobalInterner.intern("age2"), age2Reg, GlobalInterner.intern(76)),
+  ]),
+  new Block("There's a + function in there and it knows whats up", [
+    new JoinNode([
+      new Scan(p1Reg, GlobalInterner.intern("age"), age1Reg, null),
+      new Scan(p2Reg, GlobalInterner.intern("age"), age2Reg, null),
+      FunctionConstraint.create("+", {a: age1Reg, b: age2Reg, result: resultReg})!
+    ]),
+    new InsertNode(GlobalInterner.intern("adds-to"), GlobalInterner.intern("age1"), age1Reg, GlobalInterner.intern(76)),
+    new InsertNode(GlobalInterner.intern("adds-to"), GlobalInterner.intern("age2"), age2Reg, GlobalInterner.intern(76)),
+    new InsertNode(GlobalInterner.intern("adds-to"), GlobalInterner.intern("result"), resultReg, GlobalInterner.intern(76)),
   ]),
 ];
 


### PR DESCRIPTION
Mostly working*

This is still busted for interesting functions (where not all fields can be sourced from the `input` change) because (I think) our scans are being too greedy about using only values from the input rather than the index thanks to `acceptInput`. I added a useless `=` function as a PoC that seems okay for filtering, and + works (so long as it meets the requirement above).

```
search
  [age:age1]
  [age:age2]
  age1 > age2
commit
  [age1 age2]
```