### PR TITLE
Fix Interner.release for the first interned object

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -55,7 +55,7 @@ export class Interner {
   }
 
   release(id: ID|undefined) {
-    if(!id) return;
+    if(id === undefined) return;
 
     this.IDRefCount[id]--;
     if(!this.IDRefCount[id]) {


### PR DESCRIPTION
A first interned object will have an id of 0. Therefore `if(!id) return` will wrongfully terminate release of it.
Also slightly faster :D

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/749)
<!-- Reviewable:end -->
