### PR TITLE
Fix a leak in Interner.release

### DIFF
--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -73,8 +73,13 @@ export class Interner {
     this.IDRefCount[id]--;
     if(!this.IDRefCount[id]) {
       let value = this.IDs[id];
-      this.numbers[value as number] = undefined;
-      this.strings[value as string] = undefined;
+      let coll;
+      if(isNumber(value)) {
+        coll = this.numbers;
+      } else {
+        coll = this.strings;
+      }
+      coll[value] = undefined;
       this.IDFreeList.push(id);
     }
   }


### PR DESCRIPTION
Currently, each time an interned number is released an extra slot is allocated in interned strings storage (with value of undefined) which won't be reclaimable and vice-versa.

Either a check on an interned value type should be added or `delete` could be used (to prevent branching while fixing the issue).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/witheve/eve/750)
<!-- Reviewable:end -->
