### PR TITLE
performance tweaks, add a hash index

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,19 +21,12 @@
     <link href="assets/favicon.png" rel="icon" type="image/png" />
   </head>
   <body>
-    <script type="text/javascript" src="build/workspaces.js"></script>
-    <script type="text/javascript" src="build/src/uuid.js"></script>
-    <script type="text/javascript" src="build/src/codemirror.js"></script>
-    <script type="text/javascript" src="build/src/css.js"></script>
-    <script type="text/javascript" src="build/src/simplescrollbars.js"></script>
-    <script type="text/javascript" src="build/src/annotatescrollbar.js"></script>
-    <script type="text/javascript" src="build/src/commonmark.js"></script>
-    <script type="text/javascript" src="build/src/microReact.js"></script>
-    <script type="text/javascript" src="build/src/system.js"></script>
-    <script type="text/javascript" src="build/src/systemJSConfig.js"></script>
+    <script type="text/javascript" src="src/system.js"></script>
+    <script type="text/javascript" src="src/systemJSConfig.js"></script>
     <script>
-      SystemJS.import("client");
+      SystemJS.import("runtime");
     </script>
+
     <!-- PRODUCTION ANALYTICS -->
   </body>
 </html>

--- a/src/runtime/indexes.ts
+++ b/src/runtime/indexes.ts
@@ -199,7 +199,7 @@ export class HashIndex implements Index {
     }
   }
 
-  // check that there is at least one value in the index that matches the
+  // This function checks that there is at least one value in the index that matches the
   // given pattern. If a level is free, we have to run through the potential values
   // until we come across one that could match or we run out of values to check.
   walkCheck(index:any, a:ResolvedValue, b:ResolvedValue, c:ResolvedValue, n:ResolvedValue, transaction:number, round:number):boolean {

--- a/src/runtime/indexes.ts
+++ b/src/runtime/indexes.ts
@@ -199,6 +199,9 @@ export class HashIndex implements Index {
     }
   }
 
+  // check that there is at least one value in the index that matches the
+  // given pattern. If a level is free, we have to run through the potential values
+  // until we come across one that could match or we run out of values to check.
   walkCheck(index:any, a:ResolvedValue, b:ResolvedValue, c:ResolvedValue, n:ResolvedValue, transaction:number, round:number):boolean {
     let bIx = index[a as ID];
     if(!bIx) return false;

--- a/src/runtime/indexes.ts
+++ b/src/runtime/indexes.ts
@@ -1,0 +1,272 @@
+
+import {Proposal, Change, ResolvedValue, createArray, createHash, IGNORE_REG, ID, EAVN, EAVNField, Register, Constraint, ALLOCATION_COUNT} from "./runtime";
+
+//------------------------------------------------------------------------
+// Utils
+//------------------------------------------------------------------------
+
+function isResolved(field:ResolvedValue): field is ID {
+  return field !== undefined && field !== IGNORE_REG;
+}
+
+function sumTimes(ntrcArray:number[], transaction:number, round:number) {
+  if(!ntrcArray) return 0;
+  let total = 0;
+  for(let i = 0, len = ntrcArray.length; i < len; i += 4) {
+    let t = ntrcArray[i + 1];
+    let r = ntrcArray[i + 2];
+    if(t <= transaction && r <= round) total += ntrcArray[i + 3];
+  }
+  return total;
+}
+
+//------------------------------------------------------------------------
+// Indexes
+//------------------------------------------------------------------------
+
+export interface Index {
+  insert(change:Change):void;
+  propose(proposal:Proposal, e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction:number, round:number):Proposal;
+  resolveProposal(proposal:Proposal):any[][];
+  get(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction:number, round:number):EAVN[];
+  check(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction:number, round:number):boolean;
+}
+
+export class ListIndex implements Index {
+  changes: Change[] = createArray();
+  insert(change:Change) {
+     this.changes.push(change);
+  }
+
+  resolveProposal(proposal:Proposal) {
+    return proposal.info;
+  }
+
+  propose(proposal:Proposal, e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity) {
+    let final = createArray("indexProposeResults") as ID[][];
+    let forFields:EAVNField[] = createArray("indexForFields");
+    let seen = createHash();
+
+    if(a === undefined) forFields.push("a");
+    else if(v === undefined) forFields.push("v");
+    else if(e === undefined) forFields.push("e");
+    else if(n === undefined) forFields.push("n");
+
+    for(let change of this.changes) {
+      if((e === undefined || e === IGNORE_REG || e === change.e) &&
+         (a === undefined || a === IGNORE_REG || a === change.a) &&
+         (v === undefined || v === IGNORE_REG || v === change.v) &&
+         (n === undefined || n === IGNORE_REG || n === change.n) &&
+         (change.transaction <= transaction) &&
+         (change.round <= round)) {
+        let current = change[forFields[0]];
+        if(!seen[current]) {
+          seen[current] = true;
+          final.push([current]);
+        }
+      }
+    }
+
+    proposal.cardinality = final.length;
+    proposal.info = final;
+    proposal.forFields = forFields;
+    return proposal;
+  }
+
+  check(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity):boolean {
+    for(let change of this.changes) {
+      if((e === undefined || e === IGNORE_REG || e === change.e) &&
+         (a === undefined || a === IGNORE_REG || a === change.a) &&
+         (v === undefined || v === IGNORE_REG || v === change.v) &&
+         (n === undefined || n === IGNORE_REG || n === change.n) &&
+         (change.transaction <= transaction) &&
+         (change.round <= round)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  get(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity):EAVN[] {
+    let final = createArray() as EAVN[];
+    for(let change of this.changes) {
+      if((e === undefined || e === IGNORE_REG || e === change.e) &&
+         (a === undefined || a === IGNORE_REG || a === change.a) &&
+         (v === undefined || v === IGNORE_REG || v === change.v) &&
+         (n === undefined || n === IGNORE_REG || n === change.n) &&
+         (change.transaction <= transaction) &&
+         (change.round <= round)) {
+        final.push(new EAVN(change.e, change.a, change.v, change.n))
+      }
+    }
+    return final;
+  }
+}
+
+function specialCreateArray() {
+  return createArray("hashVix");
+}
+
+export class HashIndex implements Index {
+  eavIndex = createHash();
+  aveIndex = createHash();
+  cardinality = 0;
+
+  getOrCreate(parent:any, key:any, createFunc:Function) {
+    let found = parent[key];
+    if(!found) {
+      // if(!ALLOCATION_COUNT["hashlevel"]) ALLOCATION_COUNT["hashlevel"] = 0;
+      // ALLOCATION_COUNT["hashlevel"]++;
+      found = parent[key] = createFunc();
+    }
+    return found;
+  }
+
+  insert(change:Change) {
+    let {getOrCreate} = this;
+    let eIx = getOrCreate(this.eavIndex, change.e, createHash);
+    let aIx = getOrCreate(eIx, change.a, createHash);
+    let vIx = getOrCreate(aIx, change.v, specialCreateArray);
+    vIx.push(change.n, change.transaction, change.round, change.count);
+
+    aIx = getOrCreate(this.aveIndex, change.a, createHash);
+    vIx = getOrCreate(aIx, change.v, createHash);
+    eIx = getOrCreate(vIx, change.e, specialCreateArray);
+    eIx.push(change.n, change.transaction, change.round, change.count);
+
+    this.cardinality++;
+  }
+
+  resolveProposal(proposal:Proposal) {
+    return proposal.info;
+  }
+
+  propose(proposal:Proposal, e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity) {
+    let forFields = proposal.forFields;
+    forFields.length = 0;
+    if(isResolved(e)) {
+      return this.walkPropose(proposal, this.eavIndex, e, a, v, n, "a", "v", transaction, round);
+    } else if(isResolved(a)) {
+      return this.walkPropose(proposal, this.aveIndex, a, v, e, n, "v", "e", transaction, round);
+    } else {
+      // propose for attribute since that's likely to be the smallest
+      forFields[0] = "a";
+      proposal.info = Object.keys(this.aveIndex);
+      proposal.cardinality = proposal.info.length;
+    }
+    return proposal;
+  }
+
+  walkPropose(proposal:Proposal, index:any, a:ResolvedValue, b:ResolvedValue, c:ResolvedValue, n:ResolvedValue,
+              fieldB:EAVNField, fieldC:EAVNField, transaction:number, round:number):Proposal {
+    let {forFields} = proposal;
+    let bIx = index[a as ID];
+    if(!bIx) {
+      proposal.cardinality = 0;
+      return proposal;
+    }
+    if(isResolved(b)) {
+      let cIx = bIx[b];
+      if(!cIx) {
+        proposal.cardinality = 0;
+        return proposal;
+      }
+      if(isResolved(c)) {
+        let ntrcArray = cIx[c];
+        if(sumTimes(ntrcArray, transaction, round) > 0) {
+          proposal.skip = true;
+          return proposal;
+        } else {
+          proposal.cardinality = 0;
+          return proposal;
+        }
+      } else {
+        forFields[0] = fieldC;
+        proposal.info = Object.keys(cIx);
+        proposal.cardinality = proposal.info.length;
+        return proposal;
+      }
+    } else {
+      forFields[0] = fieldB;
+      proposal.info = Object.keys(bIx);
+      proposal.cardinality = proposal.info.length;
+      return proposal;
+    }
+  }
+
+  walkCheck(index:any, a:ResolvedValue, b:ResolvedValue, c:ResolvedValue, n:ResolvedValue, transaction:number, round:number):boolean {
+    let bIx = index[a as ID];
+    if(!bIx) return false;
+    if(isResolved(b)) {
+      let cIx = bIx[b];
+      if(!cIx) return false;
+      if(isResolved(c)) {
+        let ntrcArray = cIx[c];
+        return sumTimes(ntrcArray, transaction, round) > 0;
+      } else {
+        for(let key of Object.keys(cIx)) {
+          let ntrcArray = cIx[key];
+          if(sumTimes(ntrcArray, transaction, round) > 0) {
+            return true;
+          }
+        }
+        return false;
+      }
+    } else {
+      for(let key of Object.keys(bIx)) {
+        let cIx = bIx[key];
+        if(!cIx) return false;
+        if(isResolved(c)) {
+          let ntrcArray = cIx[c];
+          return sumTimes(ntrcArray, transaction, round) > 0;
+        } else {
+          for(let key of Object.keys(cIx)) {
+            let ntrcArray = cIx[key];
+            if(sumTimes(ntrcArray, transaction, round) > 0) {
+              return true;
+            }
+          }
+          return false;
+        }
+      }
+    }
+    return false;
+  }
+
+  check(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity):boolean {
+    if(isResolved(e)) {
+      return this.walkCheck(this.eavIndex, e, a, v, n, transaction, round);
+    } else if(isResolved(a)) {
+      return this.walkCheck(this.aveIndex, a, v, e, n, transaction, round);
+    }
+    return true;
+  }
+
+  get(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity):EAVN[] {
+    let final = createArray() as EAVN[];
+    return final;
+  }
+}
+
+
+export class MatrixIndex implements Index {
+  insert(change:Change) {
+  }
+
+  resolveProposal(proposal:Proposal) {
+    return createArray();
+  }
+
+  propose(proposal:Proposal, e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity) {
+    return proposal;
+  }
+
+  check(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity):boolean {
+    return false;
+  }
+
+  get(e:ResolvedValue, a:ResolvedValue, v:ResolvedValue, n:ResolvedValue, transaction = Infinity, round = Infinity):EAVN[] {
+    let final = createArray() as EAVN[];
+    return final;
+  }
+}

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -40,7 +40,9 @@ type Multiplicity = number;
 
 export var ALLOCATION_COUNT:any = {};
 
-export function createHash() {
+export function createHash(place = "unknown-hash") {
+  if(!ALLOCATION_COUNT[place]) ALLOCATION_COUNT[place] = 0;
+  ALLOCATION_COUNT[place]++;
   return Object.create(null);
 }
 
@@ -884,7 +886,7 @@ class JoinNode implements Node {
     }
 
     let {proposer} = bestProposal;
-    // We have to slice here because we need to keep a reference to this even if later
+    // We have to copy here because we need to keep a reference to this even if later
     // rounds might overwrite the proposal
     moveArray(bestProposal.forRegisters, forRegisters);
     let resolved = proposer.resolveProposal(index, prefix, bestProposal, transaction, round, proposedResults);

--- a/src/systemJSConfig.js
+++ b/src/systemJSConfig.js
@@ -1,5 +1,5 @@
 SystemJS.config({
-  baseURL: "/build/src",
+  baseURL: "build/",
   defaultJSExtensions: true,
   map: {fs: "@empty", path: "@empty", glob: "@empty", mkdirp: "@empty"},
   meta: {"/build/src/codemirror.js": { format: "cjs" }}


### PR DESCRIPTION
This pulls indexes out into their own file so we can have a few different types. It also fixes a couple of show-stopping performance issues, reduces allocations a fair amount, and generally gets us into pretty good performance territory.

Before these changes the test case at the bottom took 16s, it's now ~300ms. The previous runtime couldn't do more than 3k updates (this does 10k) and hit ~75s doing so.