### PR TITLE
BinaryFlow and AntiJoin nodes, hookup DSL not

### DIFF
--- a/test/foundation.ts
+++ b/test/foundation.ts
@@ -387,3 +387,40 @@ test("Nested attribute lookup", (assert) => {
 
   assert.end();
 });
+
+
+test("Basic not", (assert) => {
+
+  // -----------------------------------------------------
+  // program
+  // -----------------------------------------------------
+
+  let prog = new Program("test");
+  prog.block("simple block", ({find, record, lib, not}) => {
+    let person = find("person");
+    not((subblock) => {
+      person.age;
+    })
+    return [
+      person.add("tag", "old")
+    ]
+  });
+
+  // -----------------------------------------------------
+  // verification
+  // -----------------------------------------------------
+
+  verify(assert, prog, [
+    [1, "tag", "person"],
+  ], [
+    [1, "tag", "old", 1]
+  ])
+
+  verify(assert, prog, [
+    [1, "age", 20],
+  ], [
+    [1, "tag", "old", 1, -1]
+  ])
+
+  assert.end();
+});


### PR DESCRIPTION
This change adds an AntiJoin node type that serves as the basis for blocks that contain a logical negation in them. It also hooks up the DSLNot node that we created and adds a simple test to show what using not looks like.