### PR TITLE
Runtime aggregates

### DIFF
--- a/src/runtime/dsl.ts
+++ b/src/runtime/dsl.ts
@@ -37,7 +37,7 @@ function toValue(a?:DSLNode):DSLValue {
     return a.value;
   } if(a instanceof DSLRecord) {
     return a.__record.value;
-  } if(a instanceof DSLFunction) {
+  } if(a instanceof DSLFunction || a instanceof DSLAggregate) {
     return a.returnValue.value;
   }
   return a;
@@ -48,7 +48,7 @@ function maybeVariable(maybeVariable?:DSLNode):DSLVariable|undefined {
     return maybeVariable;
   } else if(maybeVariable instanceof DSLRecord) {
     return maybeVariable.__record;
-  } else if(maybeVariable instanceof DSLFunction) {
+  } else if(maybeVariable instanceof DSLFunction || maybeVariable instanceof DSLAggregate) {
     return maybeVariable.returnValue;
   }
 }
@@ -69,7 +69,7 @@ function isRecord(a:any): a is DSLRecord {
 //--------------------------------------------------------------------
 
 type DSLVariableParent = DSLFunction|DSLRecord|DSLLookup;
-type DSLNode = DSLFunction|DSLRecord|DSLVariable|RawValue;
+type DSLNode = DSLFunction|DSLRecord|DSLVariable|DSLAggregate|RawValue;
 
 type DSLValue = RawValue|Register;
 class DSLVariable {
@@ -408,6 +408,94 @@ class DSLRecord {
 }
 
 //--------------------------------------------------------------------
+// DSLAggregate
+//--------------------------------------------------------------------
+
+class DSLAggregate {
+  __id:number = CURRENT_ID++;
+  returnValue: DSLVariable;
+
+  constructor(public __block:DSLBlock, public aggregate:any, public projection:DSLNode[], public group:DSLNode[], public args:any[], returnValue?:DSLVariable) {
+    if(returnValue) {
+      this.returnValue = returnValue;
+    } else {
+      this.returnValue = new DSLVariable("returnValue");
+      __block.registerVariable(toVariable(this.returnValue));
+    }
+    // add all of our args to our projection
+    for(let arg of args) {
+      let value = toValue(arg);
+      if(isRegister(value)) {
+        projection.push(arg);
+      }
+    }
+  }
+
+  getInputRegisters() {
+    let items = concatArray([], this.args);
+    concatArray(items, this.projection);
+    concatArray(items, this.group);
+    return this.args.map(toValue).filter(isRegister);
+  }
+
+  getOutputRegisters() {
+    let value = toValue(this.returnValue)
+    return [value];
+  }
+
+  compile() {
+    let final = [];
+    let groupRegisters = this.group.map(toValue).filter(isRegister);
+    let projectRegisters = this.projection.map(toValue).filter(isRegister);
+    let inputs = this.args.map(toValue).map(maybeIntern);
+    let agg = new this.aggregate(groupRegisters, projectRegisters, inputs, this.getOutputRegisters());
+    final.push(agg);
+    return final;
+  }
+
+  per(...args:DSLNode[]) {
+    for(let arg of args) {
+      this.group.push(arg);
+    }
+  }
+}
+
+class DSLAggregateBuilder {
+
+  group:DSLNode[] = [];
+
+  constructor(public __block:DSLBlock, public projection:DSLNode[]) {
+  }
+
+  per(...args:DSLNode[]) {
+    for(let arg of args) {
+      this.group.push(arg);
+    }
+  }
+
+  checkBlock() {
+    let active = this.__block.getActiveBlock();
+    if(active !== this.__block) throw new Error("Cannot gather in one scope and aggregate in another");
+  }
+
+  sum(value:DSLNode[]) {
+    this.checkBlock();
+    let agg = new DSLAggregate(this.__block, runtime.SumAggregate, this.projection, this.group, [value]);
+    this.__block.aggregates.push(agg);
+    return agg;
+  }
+
+  count() {
+    this.checkBlock();
+    let agg = new DSLAggregate(this.__block, runtime.SumAggregate, this.projection, this.group, [1]);
+    this.__block.aggregates.push(agg);
+    return agg;
+  }
+
+}
+
+
+//--------------------------------------------------------------------
 // DSLBlock
 //--------------------------------------------------------------------
 
@@ -420,6 +508,7 @@ class DSLBlock {
   lookups:DSLLookup[] = [];
   variables:DSLVariable[] = [];
   functions:DSLFunction[] = [];
+  aggregates:DSLAggregate[] = [];
   cleanFunctions:(DSLFunction|undefined)[] = [];
   nots:DSLNot[] = [];
   chooses:DSLChoose[] = [];
@@ -548,6 +637,11 @@ class DSLBlock {
       this.registerVariable(result);
     }
     return node.results[0];
+  }
+
+  gather = (...projection:DSLNode[]) => {
+    let active = this.getActiveBlock();
+    return new DSLAggregateBuilder(active, projection);
   }
 
   registerVariable(variable:DSLVariable) {
@@ -706,15 +800,16 @@ class DSLBlock {
     let providerToLevel:{[id:number]: number} = {};
     let items = concatArray([], this.chooses);
     concatArray(items, this.unions);
+    concatArray(items, this.aggregates);
     for(let item of items) {
-      for(let result of item.results) {
-        let value = toValue(result);
-        if(isRegister(value) && !supported[value.offset]) {
-          let found = leveledRegisters[value.offset];
+      for(let result of item.getOutputRegisters()) {
+        let offset = result.offset;
+        if(!supported[offset]) {
+          let found = leveledRegisters[offset];
           if(!found) {
-            found = leveledRegisters[value.offset] = {level: 1, providers: []};
+            found = leveledRegisters[offset] = {level: 1, providers: []};
           }
-          leveledRegisters[value.offset].providers.push(item);
+          leveledRegisters[offset].providers.push(item);
           providerToLevel[item.__id] = 1;
           changed = true;
           maxLevel = 1;
@@ -774,7 +869,7 @@ class DSLBlock {
     // represent each level
     let levels:any = [];
     for(let ix = 0; ix <= maxLevel; ix++) {
-      levels[ix] = {records: [], nots: [], lookups: [], chooses: [], unions: [], cleanFunctions: []};
+      levels[ix] = {records: [], nots: [], lookups: [], chooses: [], unions: [], cleanFunctions: [], aggregates: []};
     }
 
     // all database scans are at the first level
@@ -806,6 +901,11 @@ class DSLBlock {
     for(let union of this.unions) {
       let level = providerToLevel[union.__id] || 0;
       levels[level].unions.push(union);
+    }
+
+    for(let aggregate of this.aggregates) {
+      let level = providerToLevel[aggregate.__id] || 0;
+      levels[level].aggregates.push(aggregate);
     }
 
     return levels;
@@ -882,6 +982,11 @@ class DSLBlock {
         // For why we pass items down, see the comment about not
         union.compile(items);
         join = new runtime.BinaryJoinRight(join, union.node, union.node.registers);
+      }
+
+      for(let aggregate of level.aggregates) {
+        let aggregateNode = aggregate.compile()[0];
+        join = new runtime.MergeAggregateFlow(join, aggregateNode, aggregate.getInputRegisters(), aggregate.getOutputRegisters());
       }
 
       nodes.push(join)
@@ -1187,6 +1292,30 @@ export class Program {
     return this;
   }
 }
+
+  // let prog = new Program("test");
+  // prog.block("simple block", ({find, record, lib, choose, union, not, lookup, gather}) => {
+  //   let person = find("person");
+  //   let count = gather(person).count();
+  //   return [
+  //     record("html/div", {text: count})//.add(attribute, value)
+  //   ];
+  // });
+  // prog.test(1, [
+  //   [1, "tag", "person"],
+  //   [2, "tag", "person"],
+  // ]);
+  // prog.test(2, [
+  //   [1, "tag", "person", 0, -1],
+  // ]);
+  // prog.test(3, [
+  //   [2, "tag", "person", 0, -1],
+  // ]);
+  // prog.test(3, [
+  //   [2, "tag", "person"],
+  // ]);
+  // console.log(prog);
+
 
   // let prog = new Program("test");
   // prog.block("simple block", ({find, record, lib, choose, union, not, lookup}) => {

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -1523,6 +1523,33 @@ export class ChooseFlow {
   }
 }
 
+abstract class AggregateFlow implements Node {
+  groupKey:Function;
+  projectKey:Function;
+  groups:{[group:string]: {result:{[round:number]: RawValue}, [projection:string]: Multiplicity[]}} = {};
+
+  constructor(public groupRegisters:Register[], public projectRegisters:Register[]) {
+    this.groupKey = IntermediateIndex.CreateKeyFunction(groupRegisters);
+    this.projectKey = IntermediateIndex.CreateKeyFunction(projectRegisters);
+  }
+
+  groupPrefix(prefix:ID[]) {
+    let group = this.groupKey(prefix);
+    let projection = this.projectKey(prefix);
+    let prefixCount = prefix[prefix.length - 1];
+    let delta = 0;
+    let found = this.groups[group];
+    if(!found) {
+      found = this.groups[group] = {};
+      delta = 1;
+    }
+
+  }
+
+  abstract exec(index:Index, input:Change, prefix:ID[], transaction:number, round:number, results:Iterator<ID[]>, changes:Transaction):boolean;
+
+}
+
 //------------------------------------------------------------------------------
 // Block
 //------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds basic commutative aggregates to the runtime, using `sum` as the motivating example. Right now, aggregates are going to be pretty slow and do a lot of scary crossing at the end that we will ultimately need to find a way around, but this will work for the moment.