### PR TITLE
Support all DOM events

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -55,3 +55,4 @@ function doIt() {
 doIt();
 // import "./programs/flappy";
 // import "./programs/hover";
+// import "./programs/events";

--- a/src/programs/events.ts
+++ b/src/programs/events.ts
@@ -18,7 +18,7 @@ prog
               height: calc(100% - 200px); overflow: scroll; width: 500px;
               border: 1px solid #aaa; margin: 25px;
             }
-            .input { width: 500px; margin: 25px; }
+            .input { width: 500px; margin: 0 25px 0 25px; }
           `),
         record("html/div", {sort: 0, class: "eventer", on: [
           "mouseenter",

--- a/src/programs/events.ts
+++ b/src/programs/events.ts
@@ -1,0 +1,65 @@
+import {Program} from "../runtime/dsl2";
+import "../watchers/system";
+
+let prog = new Program("hover");
+prog.attach("system");
+prog.attach("html");
+
+prog
+  .block("Top level div", ({find, record}) => {
+    let main = find("main");
+
+    return [
+      main.add("children", [
+        record("html/style")
+          .add("text", `
+            .eventer {background-color: #75507b;  width: 100px; height: 100px; margin: 25px; }
+            .log {
+              height: calc(100% - 200px); overflow: scroll; width: 500px;
+              border: 1px solid #aaa; margin: 25px;
+            }
+            .input { width: 500px; margin: 25px; }
+          `),
+        record("html/div", {sort: 0, class: "eventer", on: [
+          "mouseenter",
+          "mouseleave",
+          "dblclick",
+          "click",
+        ]}),
+        record("html/input", {sort: 1, class: "input", on: [
+          "input",
+          "focus",
+          "blur",
+        ]}),
+        record("html/div", "log", {sort: 2, class: "log"}),
+      ])
+    ];
+  });
+
+prog
+  .commit("event handler", ({find, record}) => {
+    let log = find("log");
+    let event = find("dom/event");
+    return [
+      log.add("children", [
+        record("html/div", {text: `${event.event} on <${event.element.tagname}>`, event}),
+      ])
+    ];
+  });
+
+prog
+  .block("Translate elements into html", ({find, record}) => {
+    let elem = find("html/div");
+    return [elem.add("tag", "html/element").add("tagname", "div")];
+  })
+  .block("Translate elements into html", ({find, record}) => {
+    let elem = find("html/input");
+    return [elem.add("tag", "html/element").add("tagname", "input")];
+  })
+  .block("Translate elements into html", ({find, record}) => {
+    let elem = find("html/style");
+    return [elem.add("tag", "html/element").add("tagname", "style")];
+  });
+
+
+prog.inputEavs([ [1, "tag", "main"] ]);

--- a/src/programs/hover.ts
+++ b/src/programs/hover.ts
@@ -32,7 +32,7 @@ prog
 prog
   .commit("mouseenter", ({find, record}) => {
     let elem = find("effect");
-    let event = find("html/event", {event: "mouseenter"});
+    let event = find("dom/event", {event: "mouseenter"});
     return [
       elem.add("class", "visible")
     ];
@@ -41,7 +41,7 @@ prog
 prog
   .commit("mouseleave", ({find, record}) => {
     let elem = find("effect");
-    let event = find("html/event", {event: "mouseleave"});
+    let event = find("dom/event", {event: "mouseleave"});
     return [
       elem.remove("class", "visible")
     ];

--- a/src/programs/hover.ts
+++ b/src/programs/hover.ts
@@ -20,8 +20,8 @@ prog
           `),
         record("html/div", {sort: 0})
           .add("class", "cause")
-          .add("tag", "html/onmouseenter")
-          .add("tag", "html/onmouseleave"),
+          .add("on", "mouseenter")
+          .add("on", "mouseleave"),
         record("html/div", {sort: 1})
           .add("class", "effect")
           .add("tag", "effect")
@@ -32,7 +32,7 @@ prog
 prog
   .commit("mouseenter", ({find, record}) => {
     let elem = find("effect");
-    let event = find("html/event/mouseenter");
+    let event = find("html/event", {event: "mouseenter"});
     return [
       elem.add("class", "visible")
     ];
@@ -41,7 +41,7 @@ prog
 prog
   .commit("mouseleave", ({find, record}) => {
     let elem = find("effect");
-    let event = find("html/event/mouseleave");
+    let event = find("html/event", {event: "mouseleave"});
     return [
       elem.remove("class", "visible")
     ];

--- a/src/watchers/dom.ts
+++ b/src/watchers/dom.ts
@@ -325,7 +325,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
 
     this.program
       .commit("Remove events", ({find}) => {
-        let event = find("html/event");
+        let event = find("dom/event");
         return [
           event.remove("tag"),
         ];

--- a/src/watchers/html.ts
+++ b/src/watchers/html.ts
@@ -60,43 +60,6 @@ class HTMLWatcher extends DOMWatcher<Instance> {
 
       this._sendEvent(eavs);
     });
-
-    this.program
-      .watch("setup events", ({find, record, lookup}) => {
-        let instance = find("html/instance");
-        let {element} = instance;
-        let {attribute, value: event} = lookup(element);
-        attribute == "on";
-
-        return [
-          record({element, instance, event})
-        ]
-      })
-      .asObjects<{element:ID, instance:RawValue, event:string}>(({adds, removes}) => {
-        Object.keys(adds).forEach((id) => {
-          let {instance, event, element} = adds[id];
-
-          let domInstance = this.getInstance(instance)!;
-          domInstance.addEventListener(event, () => {
-            let changes:any[] = [];
-            let eventId = uuid();
-            changes.push(
-              [eventId, "tag", "html/event"],
-              [eventId, "event", event],
-              [eventId, "element", element],
-            );
-            this._sendEvent(changes);
-          });
-        })
-      });
-
-    this.program
-      .commit("Remove events", ({find}) => {
-        let event = find("html/event");
-        return [
-          event.remove("tag"),
-        ];
-      })
   }
 }
 


### PR DESCRIPTION
* [x] subscribe to events by `[… on: "mouseenter"]`
* [x] change `[#html/event/…]` to `[#dom/event, event: …]`
* [x] add `events.ts` example
* [ ] remove listeners when removing `on` attribute
* [ ] change old `[#html/event/click]` to `[#dom/event, event: "click"]`
* [ ] get access to `<input>` value (likely in a separate PR)
* [ ] `event.remove("tag")` → `event.remove()` once PR #797 is part of `refactor-runtime` branch

PR is not finished because I'm not sure about `[#dom/event, event: "click"]` part and about the explicit subscription. Comments?

![untitled](https://cloud.githubusercontent.com/assets/510678/23963351/a3518994-09b9-11e7-8b9c-ebce575a865b.gif)
