### PR TITLE
add free AV remove and a test

### DIFF
--- a/src/programs/compiler.ts
+++ b/src/programs/compiler.ts
@@ -59,7 +59,7 @@ prog.inputEavs([
   ["v2Record", "tag", "eve/compiler/output"],
   ["v2Record", "tag", "eve/compiler/remove"],
   ["v2Record", "record", "v1"],
-  ["v2Record", "attribute", "v1TagEmployee"],
+  // ["v2Record", "attribute", "v1TagEmployee"],
 
     // ["v2TagText", "attribute", "tag"],
     // ["v2TagText", "value", "ui/text"],

--- a/src/runtime/dsl2.ts
+++ b/src/runtime/dsl2.ts
@@ -1183,7 +1183,9 @@ export class Remove extends Insert {
       let n = uuid();
       let internedV:any = context.maybeInterned(v); // @FIXME
       internedV = internedV !== undefined ? internedV : Runtime.IGNORE_REG;
-      nodes.push(new Runtime.RemoveNode(e, context.interned(a), internedV, context.interned(n)));
+      let internedA:any = context.maybeInterned(a); // @FIXME
+      internedA = internedA !== undefined ? internedA : Runtime.IGNORE_REG;
+      nodes.push(new Runtime.RemoveNode(e, internedA, internedV, context.interned(n)));
     }
     return nodes;
   }
@@ -1246,7 +1248,9 @@ class CommitRemove extends Remove {
       let n = uuid();
       let internedV:any = context.maybeInterned(v); // @FIXME
       internedV = internedV !== undefined ? internedV : Runtime.IGNORE_REG;
-      nodes.push(new Runtime.CommitRemoveNode(e, context.interned(a), internedV, context.interned(n)));
+      let internedA:any = context.maybeInterned(a); // @FIXME
+      internedA = internedA !== undefined ? internedA : Runtime.IGNORE_REG;
+      nodes.push(new Runtime.CommitRemoveNode(e, internedA, internedV, context.interned(n)));
     }
     return nodes;
   }

--- a/src/runtime/dsl2.ts
+++ b/src/runtime/dsl2.ts
@@ -129,11 +129,11 @@ export class Reference {
   }
 
   // @TODO: allow free A's and V's here
-  remove(attribute:Value, value:Value|Value[]):Reference {
+  remove(attribute?:Value, value?:Value|Value[]):Reference {
     if(this.__owner instanceof Record) {
       // we only allow you to call remove at the root context
       if(this.__context.parent) throw new Error("Add can't be called in a sub-block");
-      this.__owner.remove(this.__context, attribute, value);
+      this.__owner.remove(this.__context, attribute as any, value as any);
       return this;
     } else {
       throw new Error("Can't call add on a non-record");
@@ -1622,7 +1622,7 @@ export class Program {
     }
     trans.exec(this.context);
     // console.timeEnd("input");
-   //  console.info(trans.changes.map((change, ix) => `    <- ${change}`).join("\n"));
+    // console.info(trans.changes.map((change, ix) => `    <- ${change}`).join("\n"));
 
     // @FIXME: Remove debugging after diagnosing compiler issue
     // let g:any = global;

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -501,8 +501,20 @@ class RemoveVsChange extends RemoveChange {
 
 class RemoveAVsChange extends RemoveVsChange {
   toRemoveChanges(context:EvaluationContext, changes:Change[]) {
-    throw new Error("Implement me!");
+    let {e,a,v,n} = this;
+    let {index, distinctIndex} = context;
+    let matches = index.get(e, IGNORE_REG, IGNORE_REG, IGNORE_REG, this.transaction, Infinity);
+    for(let {a, v} of matches) {
+      let rounds = index.getDiffs(e, a, v, IGNORE_REG);
+      for(let round of rounds) {
+        let count = this.count * (round > 0 ? 1 : -1);
+        let changeRound = Math.max(this.round, Math.abs(round) - 1);
+        let change = new RemoveChange(e!, a!, v!, n!, this.transaction, changeRound, count);
+        changes.push(change);
+      }
+    }
   }
+
   clone() {
     let {e, a, v, n, transaction, round, count} = this;
     return new RemoveAVsChange(e, a, v, n, transaction, round, count);

--- a/test/foundation.ts
+++ b/test/foundation.ts
@@ -557,3 +557,36 @@ test("commit, remove, and recursion", (assert) => {
 
   assert.end();
 });
+
+
+test("Remove: free AV", (assert) => {
+
+  // -----------------------------------------------------
+  // program
+  // -----------------------------------------------------
+
+  let prog = new Program("test");
+
+  prog.commit("coolness", ({find, not, record, choose}) => {
+    let person = find("person");
+    return [
+      person.remove()
+    ]
+  })
+
+  // -----------------------------------------------------
+  // verification
+  // -----------------------------------------------------
+
+  verify(assert, prog, [
+    [1, "tag", "person"],
+    [1, "name", "chris"],
+    [1, "age", 30],
+  ], [
+    [1, "tag", "person", 0, -1],
+    [1, "name", "chris", 0, -1],
+    [1, "age", 30, 0, -1],
+  ])
+
+  assert.end();
+});


### PR DESCRIPTION
Add the ability to call `foo.remove()` to remove all the attributes attached to a record, thus removing the record