### PR TITLE
allow arbitrary references to act like records when accessed/added/re…

### DIFF
--- a/src/runtime/dsl2.ts
+++ b/src/runtime/dsl2.ts
@@ -108,6 +108,10 @@ export class Reference {
   add(attrMap:{[attr:string]:Value|Value[]}):Reference;
   add(attribute:Value, value:Value|Value[]):Reference;
   add(attrMapOrAttr:Value|{[attr:string]:Value|Value[]}, value?:Value|Value[]):Reference {
+    if(!this.__owner) {
+      this.__owner = new Record(this.__context, [], {}, this);
+    }
+
     if(this.__owner instanceof Record) {
       // we only allow you to call add at the root context
       if(this.__context.parent) throw new Error("Add can't be called in a sub-block");
@@ -130,6 +134,10 @@ export class Reference {
 
   // @TODO: allow free A's and V's here
   remove(attribute?:Value, value?:Value|Value[]):Reference {
+    if(!this.__owner) {
+      this.__owner = new Record(this.__context, [], {}, this);
+    }
+
     if(this.__owner instanceof Record) {
       // we only allow you to call remove at the root context
       if(this.__context.parent) throw new Error("Add can't be called in a sub-block");
@@ -154,7 +162,7 @@ export class Reference {
         }
 
         if(!this.__owner) {
-          throw new Error("Cannot access a property of a static value");
+          this.__owner = new Record(active, [], {}, this);
         }
 
         return this.__owner.access(this.__context, active, prop);

--- a/test/foundation.ts
+++ b/test/foundation.ts
@@ -561,22 +561,13 @@ test("commit, remove, and recursion", (assert) => {
 
 test("Remove: free AV", (assert) => {
 
-  // -----------------------------------------------------
-  // program
-  // -----------------------------------------------------
-
   let prog = new Program("test");
-
   prog.commit("coolness", ({find, not, record, choose}) => {
     let person = find("person");
     return [
       person.remove()
     ]
   })
-
-  // -----------------------------------------------------
-  // verification
-  // -----------------------------------------------------
 
   verify(assert, prog, [
     [1, "tag", "person"],
@@ -586,6 +577,42 @@ test("Remove: free AV", (assert) => {
     [1, "tag", "person", 0, -1],
     [1, "name", "chris", 0, -1],
     [1, "age", 30, 0, -1],
+  ])
+
+  assert.end();
+});
+
+
+test("Reference: arbitrary refs act like records", (assert) => {
+
+  let prog = new Program("test");
+
+  prog.commit("coolness", ({find, not, record, union}) => {
+    let person = find("person");
+    let [thing] = union(() => {
+      return find("person");
+    }, () => {
+      return "foo";
+    })
+    return [
+      thing.remove()
+    ]
+  })
+
+  verify(assert, prog, [
+    [1, "tag", "person"],
+    [1, "name", "chris"],
+    [1, "age", 30],
+    ["foo", "tag", "person"],
+    ["foo", "name", "chris"],
+    ["foo", "age", 30],
+  ], [
+    [1, "tag", "person", 0, -1],
+    [1, "name", "chris", 0, -1],
+    [1, "age", 30, 0, -1],
+    ["foo", "tag", "person", 0, -1],
+    ["foo", "name", "chris", 0, -1],
+    ["foo", "age", 30, 0, -1],
   ])
 
   assert.end();


### PR DESCRIPTION
Make any reference behave like a record when attributes/methods are accessed on it.