### PR TITLE
Make the hover mechanics a little more ergonomic

### DIFF
--- a/src/watchers/dom.ts
+++ b/src/watchers/dom.ts
@@ -6,7 +6,7 @@ import naturalSort = require("javascript-natural-sort");
 export interface Map<V>{[key:string]: V}
 
 export interface Style extends Map<RawValue|undefined> {__size: number}
-export interface ElemInstance extends Element {__element?: RawValue, __styles?: RawValue[], __sort?: RawValue, style?: any}
+export interface ElemInstance extends Element {__element?: RawValue, __styles?: RawValue[], __sort?: RawValue, style?: any, listeners?: {[event:string]: boolean}}
 
 export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher {
   styles:Map<Style|undefined> = Object.create(null);

--- a/src/watchers/editor.ts
+++ b/src/watchers/editor.ts
@@ -956,7 +956,7 @@ class EditorWatcher extends Watcher {
         let molecule_cell;
         return [
           molecule_list.add("children", [
-            molecule_cell = record("editor/molecule-list/molecule", "html/element", "html/onmouseenter", "html/onmouseleave", {tagname: "div", molecule_list, molecule}),
+            molecule_cell = record("editor/molecule-list/molecule", "html/element", "html/listener/hover", {tagname: "div", molecule_list, molecule}),
             molecule_cell.add("children", [
               record("editor/molecule-list/molecule/grid", "shape/hex-grid", {molecule_cell, molecule, side, gap: 5})
             ]),
@@ -1027,7 +1027,7 @@ class EditorWatcher extends Watcher {
           () => "#aaa"
         );
         return [
-          atom_cell.add({tag: ["shape/hexagon", "html/onmouseenter", "html/onmouseleave"],  side, lineWidth, strokeStyle, x, y}).add("content", [
+          atom_cell.add({tag: ["shape/hexagon", "html/listener/hover"],  side, lineWidth, strokeStyle, x, y}).add("content", [
             record("ui/text", {atom_cell, text: node.label, style: record({color: node.color})})
           ])
         ];
@@ -1067,15 +1067,6 @@ class EditorWatcher extends Watcher {
     //--------------------------------------------------------------------
 
     this.editor
-      .commit("When an element is entered, mark it hovered.", ({find, record}) => {
-        let {element} = find("html/event/mouseenter");
-        return [element.add("tag", "html/hovered")];
-      })
-      .commit("When an element is left, clear it's hovered.", ({find, record}) => {
-        let {element} = find("html/event/mouseleave");
-        return [element.remove("tag", "html/hovered")];
-      })
-
       .commit("Clicking a molecule opens it.", ({find}) => {
         let molecule_cell = find("editor/molecule-list/molecule");
         find("html/event/click", {element: molecule_cell});

--- a/src/watchers/html.ts
+++ b/src/watchers/html.ts
@@ -143,50 +143,38 @@ export class HTMLWatcher extends DOMWatcher<Instance> {
       }
     }, true);
 
-    window.addEventListener("mouseover", (event) => {
+    document.body.addEventListener("mouseenter", (event) => {
       let {target} = event;
       if(!this.isInstance(target)) return;
 
       let eavs:(RawEAV|RawEAVC)[] = [];
-      let current:Element|null = target;
-      while(current && this.isInstance(current)) {
-        let elemId = current.__element!;
-        if(current.listeners && current.listeners["hover"]) {
-          let eventId = uuid();
-          eavs.push(
-            [eventId, "tag", "html/event/hover-in"],
-            [eventId, "element", elemId]
-          );
-          if(current === target) {
-            eavs.push([eventId, "tag", "html/direct-target"]);
-          }
-        }
-        current = current.parentElement;
+
+      let elemId = target.__element!;
+      if(target.listeners && target.listeners["hover"]) {
+        let eventId = uuid();
+        eavs.push(
+          [eventId, "tag", "html/event/hover-in"],
+          [eventId, "element", elemId]
+        );
       }
 
       if(eavs.length) this._sendEvent(eavs);
     }, true);
 
-    window.addEventListener("mouseout", (event) => {
+    document.body.addEventListener("mouseleave", (event) => {
       let {target} = event;
       if(!this.isInstance(target)) return;
 
       let eavs:(RawEAV|RawEAVC)[] = [];
-      let current:Element|null = target;
-      while(current && this.isInstance(current)) {
-        let elemId = current.__element!;
-        if(current.listeners && current.listeners["hover"]) {
+
+        let elemId = target.__element!;
+        if(target.listeners && target.listeners["hover"]) {
           let eventId = uuid();
           eavs.push(
             [eventId, "tag", "html/event/hover-out"],
             [eventId, "element", elemId]
           );
-          if(current === target) {
-            eavs.push([eventId, "tag", "html/direct-target"]);
-          }
         }
-        current = current.parentElement;
-      }
 
       if(eavs.length) this._sendEvent(eavs);
     }, true);

--- a/src/watchers/html.ts
+++ b/src/watchers/html.ts
@@ -3,7 +3,7 @@ import {DOMWatcher, ElemInstance} from "./dom";
 import {ID} from "../runtime/runtime";
 import {v4 as uuid} from "node-uuid";
 
-export interface Instance extends HTMLElement {__element?: RawValue, __styles?: RawValue[], __sort?: RawValue}
+export interface Instance extends HTMLElement {__element?: RawValue, __styles?: RawValue[], __sort?: RawValue, listeners?: {[event: string]: boolean}}
 
 export class HTMLWatcher extends DOMWatcher<Instance> {
   tagPrefix = "html";
@@ -143,6 +143,54 @@ export class HTMLWatcher extends DOMWatcher<Instance> {
       }
     }, true);
 
+    window.addEventListener("mouseover", (event) => {
+      let {target} = event;
+      if(!this.isInstance(target)) return;
+
+      let eavs:(RawEAV|RawEAVC)[] = [];
+      let current:Element|null = target;
+      while(current && this.isInstance(current)) {
+        let elemId = current.__element!;
+        if(current.listeners && current.listeners["hover"]) {
+          let eventId = uuid();
+          eavs.push(
+            [eventId, "tag", "html/event/hover-in"],
+            [eventId, "element", elemId]
+          );
+          if(current === target) {
+            eavs.push([eventId, "tag", "html/direct-target"]);
+          }
+        }
+        current = current.parentElement;
+      }
+
+      if(eavs.length) this._sendEvent(eavs);
+    }, true);
+
+    window.addEventListener("mouseout", (event) => {
+      let {target} = event;
+      if(!this.isInstance(target)) return;
+
+      let eavs:(RawEAV|RawEAVC)[] = [];
+      let current:Element|null = target;
+      while(current && this.isInstance(current)) {
+        let elemId = current.__element!;
+        if(current.listeners && current.listeners["hover"]) {
+          let eventId = uuid();
+          eavs.push(
+            [eventId, "tag", "html/event/hover-out"],
+            [eventId, "element", elemId]
+          );
+          if(current === target) {
+            eavs.push([eventId, "tag", "html/direct-target"]);
+          }
+        }
+        current = current.parentElement;
+      }
+
+      if(eavs.length) this._sendEvent(eavs);
+    }, true);
+
     this.program
       .commit("Remove input-related events.", ({find, choose}) => {
         let [event] = choose(
@@ -165,65 +213,45 @@ export class HTMLWatcher extends DOMWatcher<Instance> {
 
 
     this.program
-      .watch("setup onmouseenter", ({find, record}) => {
-        let elemId = find("html/onmouseenter");
+      .commit("When an element is entered, mark it hovered.", ({find, record}) => {
+        let {element} = find("html/event/hover-in");
+        return [element.add("tag", "html/hovered")];
+      })
+      .commit("When an element is left, clear it's hovered.", ({find, record}) => {
+        let {element} = find("html/event/hover-out");
+        return [element.remove("tag", "html/hovered")];
+      })
+
+      .watch("When an element is hoverable, it subscribes to mouseover/mouseout", ({find, record}) => {
+        let elemId = find("html/listener/hover");
         let instanceId = find("html/instance", {element: elemId});
         return [
-          record({elemId, instanceId})
+          record({listener: "hover", elemId, instanceId})
         ]
       })
-      .asObjects<{elemId:ID, instanceId:RawValue}>(({adds, removes}) => {
-        Object.keys(adds).forEach((id) => {
-          let {elemId, instanceId} = adds[id];
-          // instanceId couldn't be undefined because we've found it in .watch() above
+      .asObjects<{listener:string, elemId:ID, instanceId:RawValue}>(({adds, removes}) => {
+        for(let e of Object.keys(adds)) {
+          let {listener, elemId, instanceId} = adds[e];
           let instance = this.getInstance(instanceId)!;
-          instance.addEventListener("mouseenter", () => {
-            let changes:any[] = [];
-            let eventId = uuid();
-            changes.push(
-              [eventId, "tag", "html/event/mouseenter"],
-              [eventId, "element", elemId],
-            );
-            this._sendEvent(changes);
-          });
-        })
+          if(!instance.listeners) instance.listeners = {};
+          instance.listeners[listener] = true;
+        }
+        for(let e of Object.keys(removes)) {
+          let {listener, elemId, instanceId} = removes[e];
+          let instance = this.getInstance(instanceId)
+          if(!instance || !instance.listeners) continue;
+          instance.listeners[listener] = false;
+        }
       })
-      .watch("setup onmouseleave", ({find, record}) => {
-        let elemId = find("html/onmouseleave");
-        let instanceId = find("html/instance", {element: elemId});
-        return [
-          record({elemId, instanceId})
-        ]
-      })
-      .asObjects<{elemId:ID, instanceId:RawValue}>(({adds, removes}) => {
-        Object.keys(adds).forEach((id) => {
-          let {elemId, instanceId} = adds[id];
-          // instanceId couldn't be undefined because we've found it in .watch() above
-          let instance = this.getInstance(instanceId)!;
-          instance.addEventListener("mouseleave", () => {
-            let changes:any[] = [];
-            let eventId = uuid();
-            changes.push(
-              [eventId, "tag", "html/event/mouseleave"],
-              [eventId, "element", elemId],
-            );
-            this._sendEvent(changes);
-          });
-        })
-      });
 
     this.program
-      .commit("Remove mouseenter events", ({find}) => {
-        let event = find("html/event/mouseenter");
-        return [
-          event.remove(),
-        ];
+      .commit("Remove hover-in events", ({find}) => {
+        let event = find("html/event/hover-in");
+        return [event.remove()];
       })
-      .commit("Remove mouseleave events", ({find}) => {
-        let event = find("html/event/mouseleave");
-        return [
-          event.remove(),
-        ];
+      .commit("Remove hover-out events", ({find}) => {
+        let event = find("html/event/hover-out");
+        return [event.remove()];
       });
   }
 }


### PR DESCRIPTION
Since mouseenter and mouseleave are basically useless without each other, users should just subscribe to both at once. We've also taken the opportunity to make the subscription a little more standard. Future subscribed events will all live in the `html/listener/<event>` space.

In the off chance a user tries to use hovering on a lot of elements in their app, we've switched to mouseover/mouseout with bubbling. This leads to a lot more false positives, but only costs a single listener. Whether this is better or worse basically depends on the eve performance to browser performance ratio. In either case, it's easy to switch back if need be. We could also be a little fancier and track hover state on the elements in JS, in which case we don't need to send false events.

Finally, for convenience the html watcher will maintain an `html/hovered` tag on any elements with the hover listener based on their current hover state.