### PR TITLE
Stratification bugfixes + multi-returning function constraint support

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -1,6 +1,6 @@
 * {box-sizing: border-box;}
-html, body, __root { height: 100%; }
-body { background: #f5f5f5; color: #555; font-family: Avenir, "Helvetica neue", sans-serif; display: flex; flex-direction: column; margin:0; width: 100%; }
+html { height: 100%; }
+body { min-height: 100%; background: #f5f5f5; color: #555; font-family: Avenir, "Helvetica neue", sans-serif; display: flex; flex-direction: column; margin:0; width: 100%; }
 
 /******************************************************************************\
  * UI Components                                                              *
@@ -13,7 +13,10 @@ spacer { display: flex; flex: 1; }
 
 text { display: inline-block; white-space: pre-wrap; }
 
-.button { padding: 5px 10px; background: transparent; border: none; outline: none; -webkit-appearance: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; background-clip: padding-box !important; }
+.button { display: flex; flex-direction: row; padding: 5px 10px; background: transparent; border: none; outline: none; -webkit-appearance: none; -webkit-user-select: none; -moz-user-select: none; -ms-user-select: none; background-clip: padding-box !important; }
+
+.button:before { align-self: center; }
+.button:not(:empty):before { margin-right: 10; }
 
 .button.inset { border-radius: 4px; background: #EEE; border: 1px solid rgba(0, 0, 0, 0.1); }
 .button.inset:not(.disabled):hover { box-shadow: inset 0 0 1000px rgba(0, 0, 0, 0.05), inset 0 1px 1px rgba(0, 0, 0, 0.25); border-top-color: rgba(0, 0, 0, 0.2); }
@@ -26,15 +29,16 @@ text { display: inline-block; white-space: pre-wrap; }
 .dark .button.flat:not(.disabled):active { background: rgba(255, 255, 255, 0.2); }
 
 .ui-field-table {border-collapse: collapse;}
-.ui-field-table td {padding: 0;margin: 0;vertical-align: top; border: 1px solid #ccc;}
-.ui-field-table .ui-field-table-attribute {}
-.ui-field-table .ui-field-table-value-set {display: flex;flex-direction: column;}
-.ui-field-table .ui-field-table-cell { padding: 0 10; margin: 0; }
-.ui-field-table .ui-field-table-cell + .ui-field-table-cell { border-top: 1px solid #ccc; }
-
-.ui-field-table input.ui-field-table-cell {min-width:100%;font-size: 1em;font-weight: inherit;font-family: inherit;background: transparent;border: none;color: inherit;}
+.ui-field-table td { position: relative; padding: 0;margin: 0;vertical-align: top; border: 1px solid #ccc;}
+.ui-field-table input {width:100%;font-size: 1em;font-weight: inherit;font-family: inherit;background: transparent;border: none;color: inherit;}
 .ui-field-table input::-webkit-input-placeholder { font-weight: 300; }
 .ui-field-table input.ui-field-table-attribute {padding-right: 0;}
+
+.ui-field-table .ui-field-table-attribute { min-width: 100%; }
+.ui-field-table .ui-field-table-value-set {display: flex;flex-direction: column;}
+.ui-field-table .ui-field-table-cell { padding: 0 10; }
+.ui-field-table .ui-field-table-cell + .ui-field-table-cell { border-top: 1px solid #ccc; }
+
 
 .ui-autocomplete { position: relative; flex: 0 0 auto; width: 200;}
 .ui-autocomplete-matches { position: absolute; top: 100%; width: 100%; flex: 0 0 auto; z-index: 5; background: white; border-top: 0px solid #f0f0f0; border-radius: 4px; box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2); }

--- a/src/runtime/dsl2.ts
+++ b/src/runtime/dsl2.ts
@@ -551,7 +551,7 @@ export class FlowLevel {
             found = leveledRegisters[offset] = {level: 1, providers: []};
           }
           leveledRegisters[offset].providers.push(item);
-          providerToLevel[item.ID] = 1;
+          providerToLevel[item.ID] = 0;
           changed = true;
           maxLevel = 1;
         }
@@ -563,7 +563,7 @@ export class FlowLevel {
     concatArray(items, this.functions);
     concatArray(items, this.nots);
     concatArray(items, this.moves);
-    let remaining = items.length;
+    let remaining = items.length * items.length;
     while(changed && remaining > -1) {
       changed = false;
       for(let item of items) {
@@ -574,9 +574,9 @@ export class FlowLevel {
         let providerLevel = providerToLevel[item.ID] || 0;
         for(let input of item.getInputRegisters()) {
           let inputInfo = leveledRegisters[input.offset];
-          if(inputInfo && inputInfo.level >= providerLevel) {
+          if(inputInfo && inputInfo.level > providerLevel) {
             changedProvider = true;
-            providerLevel = inputInfo.level + 1;
+            providerLevel = inputInfo.level;
           }
         }
 
@@ -588,13 +588,13 @@ export class FlowLevel {
               if(supported[output.offset]) continue;
               let outputInfo = leveledRegisters[output.offset];
               if(!outputInfo) {
-                outputInfo = leveledRegisters[output.offset] = {level:0, providers:[]};
+                outputInfo = leveledRegisters[output.offset] = {level: 0, providers: []};
               }
               if(outputInfo.providers.indexOf(item) === -1) {
                 outputInfo.providers.push(item);
               }
-              if(outputInfo.level < providerLevel) {
-                outputInfo.level = providerLevel;
+              if(outputInfo.level <= providerLevel) {
+                outputInfo.level = providerLevel + 1;
               }
             }
           }

--- a/src/runtime/runtime.ts
+++ b/src/runtime/runtime.ts
@@ -88,6 +88,12 @@ export function printFlow(flow:ChooseFlow|UnionFlow):string {
 })`;
 }
 
+export function printAntiJoin(node:AntiJoin):string {
+  let left = indent(printNode(node.left), 2);
+  let right = indent(printNode(node.right), 2);
+  return `Antijoin({\n  left: ${left},\n  right: ${right}\n})`;
+}
+
 export function printNode(node:Node):string {
   if(node instanceof JoinNode) {
     return printJoinNode(node);
@@ -103,6 +109,8 @@ export function printNode(node:Node):string {
     return `BinaryJoinRight(${printNode(node.right)})`;
   } else if(node instanceof AntiJoinPresolvedRight) {
     return `AntiJoinPresolvedRight(${printNode(node.left)})`;
+  } else if(node instanceof AntiJoin) {
+    return printAntiJoin(node);
   } else {
     return "Unknown node type";
   }

--- a/src/runtime/stdlib.ts
+++ b/src/runtime/stdlib.ts
@@ -201,6 +201,15 @@ makeMultiFunction({
   name: "math/range",
   args: {start: "number", stop: "number"},
   returns: {result: "string"},
+  estimate: function(context, prefix) {
+    let {start, stop} = this.resolve(prefix);
+    if(typeof start !== "number" || typeof stop !== "number") return 0;
+    if(start > stop) {
+      return start - stop;
+    } else {
+      return stop - start;
+    }
+  },
   apply: (start:number, stop:number, step:number = 1) => {
     if(typeof start !== "number" || typeof stop !== "number" || typeof step !== "number") return;
     if(start > stop) {

--- a/src/runtime/stdlib.ts
+++ b/src/runtime/stdlib.ts
@@ -1,4 +1,4 @@
-import {makeFunction, RawValue, AggregateNode} from "./runtime";
+import {makeFunction, makeMultiFunction, RawValue, AggregateNode} from "./runtime";
 
 //--------------------------------------------------------------------
 // Comparisons
@@ -197,20 +197,23 @@ makeFunction({
   }
 });
 
-// makeFunction({
-//   name: "math/range",
-//   args: {start: "number", stop: "number"},
-//   returns: {result: "string"},
-//   apply: (start:number, stop:number) => {
-//     if(start > stop) {
-//       [stop, start] = [start, stop];
-//     }
+makeMultiFunction({
+  name: "math/range",
+  args: {start: "number", stop: "number"},
+  returns: {result: "string"},
+  apply: (start:number, stop:number, step:number = 1) => {
+    if(typeof start !== "number" || typeof stop !== "number" || typeof step !== "number") return;
+    if(start > stop) {
+      [stop, start] = [start, stop];
+    }
 
-//     for(let ix = start; ix < stop; ix += 1) {
-//     }
-//     return [a.toFixed(b)];
-//   }
-// });
+    let outputs = [];
+    for(let ix = start; ix <= stop; ix += step) {
+      outputs.push([ix]);
+    }
+    return outputs;
+  }
+});
 
 //--------------------------------------------------------------------
 // String

--- a/test/aggregate.ts
+++ b/test/aggregate.ts
@@ -534,32 +534,33 @@ test("Aggregate: no outer in key variations", (assert) => {
   assert.end();
 });
 
-test("Aggregate: stratified after choose", (assert) => {
-  let prog = new Program("test");
-  prog.bind("Count the next of kin", ({find, gather, choose, not, record}) => {
-    let person = find("person");
-    let [kin] = choose(() => person.family, () => person.friend, () => person.acquaintance);
-    not(() => kin.nemesis == person);
-    let count = gather(kin).per(person).count();
-    return [person.add("kin_count", count)];
-  });
+// @NOTE: The not following the choose required for this example is currently marked dangerous
+// test("Aggregate: stratified after choose", (assert) => {
+//   let prog = new Program("test");
+//   prog.bind("Count the next of kin", ({find, gather, choose, not, record}) => {
+//     let person = find("person");
+//     let [kin] = choose(() => person.family, () => person.friend, () => person.acquaintance);
+//     not(() => kin.nemesis == person);
+//     let count = gather(kin).per(person).count();
+//     return [person.add("kin_count", count)];
+//   });
 
-  verify(assert, prog, [
-    [1, "tag", "person"],
-    [1, "name", "chris"],
-    [1, "friend", "joe"],
-    [1, "friend", "fred"],
-    [1, "friend", "steve"],
-    ["steve", "nemesis", 1],
-  ], [
-    [1, "kin_count", 2, 1],
-  ]);
+//   verify(assert, prog, [
+//     [1, "tag", "person"],
+//     [1, "name", "chris"],
+//     [1, "friend", "joe"],
+//     [1, "friend", "fred"],
+//     [1, "friend", "steve"],
+//     ["steve", "nemesis", 1],
+//   ], [
+//     [1, "kin_count", 2, 1],
+//   ]);
 
-  verify(assert, prog, [
-    [1, "tag", "person", 0, -1],
-  ], [
-    [1, "kin_count", 2, 1, -1],
-  ]);
+//   verify(assert, prog, [
+//     [1, "tag", "person", 0, -1],
+//   ], [
+//     [1, "kin_count", 2, 1, -1],
+//   ]);
 
-  assert.end();
-});
+//   assert.end();
+// });

--- a/test/aggregate.ts
+++ b/test/aggregate.ts
@@ -533,3 +533,33 @@ test("Aggregate: no outer in key variations", (assert) => {
 
   assert.end();
 });
+
+test("Aggregate: stratified after choose", (assert) => {
+  let prog = new Program("test");
+  prog.bind("Count the next of kin", ({find, gather, choose, not, record}) => {
+    let person = find("person");
+    let [kin] = choose(() => person.family, () => person.friend, () => person.acquaintance);
+    not(() => kin.nemesis == person);
+    let count = gather(kin).per(person).count();
+    return [person.add("kin_count", count)];
+  });
+
+  verify(assert, prog, [
+    [1, "tag", "person"],
+    [1, "name", "chris"],
+    [1, "friend", "joe"],
+    [1, "friend", "fred"],
+    [1, "friend", "steve"],
+    ["steve", "nemesis", 1],
+  ], [
+    [1, "kin_count", 2, 1],
+  ]);
+
+  verify(assert, prog, [
+    [1, "tag", "person", 0, -1],
+  ], [
+    [1, "kin_count", 2, 1, -1],
+  ]);
+
+  assert.end();
+});

--- a/test/all.ts
+++ b/test/all.ts
@@ -4,4 +4,5 @@ import "./antijoin";
 import "./choose";
 import "./union";
 import "./aggregate";
+import "./stdlib/math";
 // import "./performance";

--- a/test/stdlib/math.ts
+++ b/test/stdlib/math.ts
@@ -1,0 +1,97 @@
+import {Program} from "../../src/runtime/dsl2";
+import {verify} from "../util";
+import * as test from "tape";
+
+test("stdlib:math:range: 1..5", (assert) => {
+  let prog = new Program("test");
+  prog.bind("test range", ({find, lib:{math}, record}) => {
+    let ix = math.range(1, 5);
+    return [
+      record({ix})
+    ];
+  });
+
+  verify(assert, prog, [
+    ["A", "tag", "turtle"],
+  ], [
+    [11, "ix", 1, 1],
+    [12, "ix", 2, 1],
+    [13, "ix", 3, 1],
+    [14, "ix", 4, 1],
+    [15, "ix", 5, 1],
+  ]);
+  assert.end();
+});
+
+test("stdlib:math:range: 3..-1", (assert) => {
+  let prog = new Program("test");
+  prog.bind("test range", ({find, lib:{math}, record}) => {
+    let ix = math.range(3, -1);
+    return [
+      record({ix})
+    ];
+  });
+
+  verify(assert, prog, [
+    ["A", "tag", "turtle"],
+  ], [
+    [11, "ix", 3, 1],
+    [12, "ix", 2, 1],
+    [13, "ix", 1, 1],
+    [14, "ix", 0, 1],
+    [15, "ix", -1, 1],
+  ]);
+  assert.end();
+});
+
+test("stdlib:math:range: x..y", (assert) => {
+  let prog = new Program("test");
+  prog.bind("test range", ({find, lib:{math}}) => {
+    let endpoints = find("endpoints");
+    let {x, y} = endpoints;
+    let ix = math.range(x, y);
+    return [
+      endpoints.add({ix})
+    ];
+  });
+
+  verify(assert, prog, [
+    ["A", "tag", "endpoints"],
+    ["A", "x", 1],
+    ["A", "y", 3],
+    ["B", "tag", "endpoints"],
+    ["B", "x", 2],
+    ["B", "y", 0],
+  ], [
+    ["A", "ix", 1, 1],
+    ["A", "ix", 2, 1],
+    ["A", "ix", 3, 1],
+    ["B", "ix", 0, 1],
+    ["B", "ix", 1, 1],
+    ["B", "ix", 2, 1],
+  ]);
+  assert.end();
+});
+
+test("stdlib:math:range: bail on strings", (assert) => {
+  let prog = new Program("test");
+  prog.bind("test range", ({find, lib:{math}}) => {
+    let endpoints = find("endpoints");
+    let {x, y} = endpoints;
+    let ix = math.range(x, y);
+    return [
+      endpoints.add({ix})
+    ];
+  });
+
+  verify(assert, prog, [
+    ["A", "tag", "endpoints"],
+    ["A", "x", "1"],
+    ["A", "y", 3],
+    ["B", "tag", "endpoints"],
+    ["B", "x", 2],
+    ["B", "y", "0"],
+  ], [
+  ]);
+  assert.end();
+});


### PR DESCRIPTION
Fixes:
* Debug print for AntiJoin nodes
* Correctly stratify nots and chooses when dependent
* Fix some other minor bugs in the stratifier
* Disable stratifying chooses/unions/nots after one another until systemic issues involving partial input execution can be fixed. These problems only effect certain edge cases, but we'd prefer to explicitly require users to type a bit more in the interim than risk them getting bitten by very unintuitive issues in the runtime. 

Adds:
* Support for function constraints that return multiple values using `makeMultiFunction`. This is a relatively naive implementation. If the branch in `resolveProposal`/`accept` proves to be expensive, we can easily specialize at construction time, at the cost of more lines of code. We could also have a more advanced iterator-like setup for streaming out results, but I don't know at what size that overhead starts to become worth it, and I don't know how we hide that complexity from implementors.
* `lib.math.range(start, stop)`. 1-indexed, with support for inverted ranges (i.e. `(5, 1)`). It internally also supports a user-specified `step`, but we haven't added support for optional parameters yet.
* Some range smoke tests.