### PR TITLE
Switch off from deprecated node-uuid package

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,15 +31,14 @@
   },
   "dependencies": {
     "@types/node": "^6.0.41",
-    "@types/node-uuid": "0.0.28",
     "@types/tape": "^4.2.28",
     "chevrotain": "^0.19.0",
     "express": "^4.14.0",
     "falafel": "^2.0.0",
     "javascript-natural-sort": "^0.7.1",
-    "node-uuid": "^1.4.7",
     "setimmediate": "^1.0.5",
-    "typescript": "^2.1.4"
+    "typescript": "^2.1.4",
+    "uuid": "^3.0.1"
   },
   "devDependencies": {
     "faucet": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@types/node": "^6.0.41",
     "@types/tape": "^4.2.28",
+    "@types/uuid": "^2.0.29",
     "chevrotain": "^0.19.0",
     "express": "^4.14.0",
     "falafel": "^2.0.0",

--- a/src/programs/perfReport.ts
+++ b/src/programs/perfReport.ts
@@ -1,7 +1,7 @@
 //---------------------------------------------------------------------
 // Performance Report
 //---------------------------------------------------------------------
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 import {Program} from "../watchers/watcher";
 import {PerformanceTracker} from "../runtime/performance";
 

--- a/src/programs/perfReport.ts
+++ b/src/programs/perfReport.ts
@@ -1,7 +1,7 @@
 //---------------------------------------------------------------------
 // Performance Report
 //---------------------------------------------------------------------
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 import {Program} from "../watchers/watcher";
 import {PerformanceTracker} from "../runtime/performance";
 

--- a/src/runtime/dsl2.ts
+++ b/src/runtime/dsl2.ts
@@ -10,7 +10,7 @@ import * as indexes from "./indexes";
 import {Watcher, Exporter, DiffConsumer, ObjectConsumer, RawRecord} from "../watchers/watcher";
 import "./stdlib";
 import {SumAggregate} from "./stdlib";
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 import * as falafel from "falafel";
 
 const UNASSIGNED = -1;

--- a/src/runtime/dsl2.ts
+++ b/src/runtime/dsl2.ts
@@ -10,7 +10,7 @@ import * as indexes from "./indexes";
 import {Watcher, Exporter, DiffConsumer, ObjectConsumer, RawRecord} from "../watchers/watcher";
 import "./stdlib";
 import {SumAggregate} from "./stdlib";
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 import * as falafel from "falafel";
 
 const UNASSIGNED = -1;

--- a/src/runtime/performance.ts
+++ b/src/runtime/performance.ts
@@ -1,7 +1,7 @@
 //---------------------------------------------------------------------
 // Performance
 //---------------------------------------------------------------------
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 // import {Program} from "./dsl2";
 
 var globalsToTrack = ["transaction"];

--- a/src/runtime/performance.ts
+++ b/src/runtime/performance.ts
@@ -1,7 +1,7 @@
 //---------------------------------------------------------------------
 // Performance
 //---------------------------------------------------------------------
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 // import {Program} from "./dsl2";
 
 var globalsToTrack = ["transaction"];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,6 @@
 declare module "falafel";
 declare module "setimmediate";
+declare module "uuid/v4";
 
 declare module "javascript-natural-sort" {
   export = naturalSort;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,6 +1,5 @@
 declare module "falafel";
 declare module "setimmediate";
-declare module "uuid/v4";
 
 declare module "javascript-natural-sort" {
   export = naturalSort;

--- a/src/watchers/canvas.ts
+++ b/src/watchers/canvas.ts
@@ -1,6 +1,6 @@
 import {Watcher, RawMap, RawValue, RawEAV, RawEAVC, maybeIntern} from "./watcher";
 import {HTMLWatcher} from "./html";
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 
 function asValue(value:RawValue) {
   if(typeof value == "string") {

--- a/src/watchers/canvas.ts
+++ b/src/watchers/canvas.ts
@@ -1,6 +1,6 @@
 import {Watcher, RawMap, RawValue, RawEAV, RawEAVC, maybeIntern} from "./watcher";
 import {HTMLWatcher} from "./html";
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 
 function asValue(value:RawValue) {
   if(typeof value == "string") {

--- a/src/watchers/dom.ts
+++ b/src/watchers/dom.ts
@@ -1,5 +1,5 @@
 import {Watcher, RawValue, RawEAV, RawEAVC} from "./watcher";
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 
 import naturalSort = require("javascript-natural-sort");
 

--- a/src/watchers/dom.ts
+++ b/src/watchers/dom.ts
@@ -1,5 +1,5 @@
 import {Watcher, RawValue, RawEAV, RawEAVC} from "./watcher";
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 
 import naturalSort = require("javascript-natural-sort");
 

--- a/src/watchers/html.ts
+++ b/src/watchers/html.ts
@@ -1,7 +1,7 @@
 import {Watcher, RawValue, RawEAV, RawEAVC, maybeIntern, ObjectDiffs, createId} from "./watcher";
 import {DOMWatcher, ElemInstance} from "./dom";
 import {ID} from "../runtime/runtime";
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 
 export interface Instance extends HTMLElement {__element?: RawValue, __styles?: RawValue[], __sort?: RawValue, listeners?: {[event: string]: boolean}}
 

--- a/src/watchers/html.ts
+++ b/src/watchers/html.ts
@@ -1,7 +1,7 @@
 import {Watcher, RawValue, RawEAV, RawEAVC, maybeIntern, ObjectDiffs, createId} from "./watcher";
 import {DOMWatcher, ElemInstance} from "./dom";
 import {ID} from "../runtime/runtime";
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 
 export interface Instance extends HTMLElement {__element?: RawValue, __styles?: RawValue[], __sort?: RawValue, listeners?: {[event: string]: boolean}}
 

--- a/src/watchers/tag-browser.ts
+++ b/src/watchers/tag-browser.ts
@@ -1,5 +1,5 @@
 import {Watcher, Program, RawMap, RawValue, RawEAVC} from "./watcher";
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 
 import {UIWatcher} from "../watchers/ui";
 

--- a/src/watchers/tag-browser.ts
+++ b/src/watchers/tag-browser.ts
@@ -1,5 +1,5 @@
 import {Watcher, Program, RawMap, RawValue, RawEAVC} from "./watcher";
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 
 import {UIWatcher} from "../watchers/ui";
 

--- a/src/watchers/ui.ts
+++ b/src/watchers/ui.ts
@@ -1,5 +1,5 @@
 import {Watcher, RawMap, RawValue, RawEAV} from "./watcher";
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 
 export interface Attrs extends RawMap<RawValue|RawValue[]|RawEAV[]> {}
 

--- a/src/watchers/ui.ts
+++ b/src/watchers/ui.ts
@@ -1,5 +1,5 @@
 import {Watcher, RawMap, RawValue, RawEAV} from "./watcher";
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 
 export interface Attrs extends RawMap<RawValue|RawValue[]|RawEAV[]> {}
 

--- a/src/watchers/watcher.ts
+++ b/src/watchers/watcher.ts
@@ -3,7 +3,7 @@ export {RawValue, RawEAV, RawEAVC} from "../runtime/runtime";
 import {ID, GlobalInterner, RawValue, RawEAV, RawEAVC, Change, createArray, ExportHandler} from "../runtime/runtime";
 export {Program} from "../runtime/dsl2";
 import {Program, LinearFlowFunction} from "../runtime/dsl2";
-import * as uuid from "uuid/v4";
+import {v4 as uuid} from "uuid";
 
 //------------------------------------------------------------------------------
 // Watcher

--- a/src/watchers/watcher.ts
+++ b/src/watchers/watcher.ts
@@ -3,7 +3,7 @@ export {RawValue, RawEAV, RawEAVC} from "../runtime/runtime";
 import {ID, GlobalInterner, RawValue, RawEAV, RawEAVC, Change, createArray, ExportHandler} from "../runtime/runtime";
 export {Program} from "../runtime/dsl2";
 import {Program, LinearFlowFunction} from "../runtime/dsl2";
-import {v4 as uuid} from "node-uuid";
+import * as uuid from "uuid/v4";
 
 //------------------------------------------------------------------------------
 // Watcher


### PR DESCRIPTION
This replaces [deprecated `node-uuid`](https://www.npmjs.com/package/node-uuid) package with [`uuid`](https://www.npmjs.com/package/uuid).

As a bonus, it shaves 92K from my app webpack bundle:

|   Filename      | before           | after  |
| :------------- |-------------:| -----:|
| main.js     | 1.2M | 649K |
| main.min.js      | 554K      |   271K |
| main.min.js.gz | 164K      |    72K |

It's because `node-uuid` was bringing huge amount of crypto packages with it.