### PR TITLE
Hotfix: use tokenMatcher from chevrotain to determine tokenType

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/node": "^6.0.41",
     "@types/tape": "^4.2.28",
     "@types/uuid": "^2.0.29",
-    "chevrotain": "^0.28.1",
+    "chevrotain": "0.28.2",
     "commonmark": "^0.27.0",
     "express": "^4.14.0",
     "falafel": "^2.0.0",

--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -5,7 +5,7 @@
 import * as commonmark from "commonmark";
 import * as chev from "chevrotain";
 import {parserErrors, EveError} from "./errors";
-var {Lexer} = chev;
+var {Lexer, tokenMatcher} = chev;
 export var Token = chev.Token;
 import * as uuid from "uuid";
 
@@ -25,7 +25,7 @@ function cleanString(str:string) {
 }
 
 function toEnd(node:any) {
-  if(node instanceof Token) {
+  if(node && node.tokenType !== undefined) {
     return node.endOffset! + 1;
   }
   return node.endOffset;
@@ -1033,7 +1033,7 @@ export class Parser extends chev.Parser {
             expression = makeNode("expression", {variable, op: `compare/${comparator.image}`, args: [asValue(curLeft), asValue(value)], from: [curLeft, comparator, value]});
             self.block.addUsage(variable, expression);
             self.block.expression(expression);
-          } else if(comparator instanceof Equality) {
+          } else if(tokenMatcher(comparator, Equality)) {
             if(value.type === "choose" || value.type === "union") {
               value.outputs = ifOutputs(left);
               self.block.scan(value);


### PR DESCRIPTION
The way tokens are exposed seems to have changed fundamentally, which broke parsing.