### PR TITLE
Fix/watcher interface multiplicity

### DIFF
--- a/src/watchers/dom.ts
+++ b/src/watchers/dom.ts
@@ -159,14 +159,14 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
         return [click.remove()];
       })
 
-      .bind("Create instances for each root.", ({find, record, lib, not}) => {
+      .bind("Create instances for each root.", ({find, record, lib}) => {
         let elem = find("{{tagPrefix}}/root");
         return [
           record("{{tagPrefix}}/instance", {element: elem, tagname: elem.tagname})
         ];
       })
 
-      .bind("Create an instance for each child of a rooted parent.", ({find, record, lib, not}) => {
+      .bind("Create an instance for each child of a rooted parent.", ({find, record, lib}) => {
         let elem = find("{{tagPrefix}}/element");
         let parentElem = find("{{tagPrefix}}/element", {children: elem});
         let parent = find("{{tagPrefix}}/instance", {element: parentElem});
@@ -239,7 +239,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
         }
       })
 
-      .watch("Export element styles.", ({find, record, lib, not, lookup}) => {
+      .watch("Export element styles.", ({find, record, lib, lookup}) => {
         let elem = find("{{tagPrefix}}/element");
         let style = elem.style;
         let {attribute, value} = lookup(style);

--- a/src/watchers/watcher.ts
+++ b/src/watchers/watcher.ts
@@ -25,7 +25,7 @@ export class Watcher {
   }
 
   static get(id:string) {
-    let watcher = this._registry[id];;
+    let watcher = this._registry[id];
     if(watcher) return watcher;
   }
 


### PR DESCRIPTION
Fix #834.

The watcher interface had a subtle but extremely dangerous flaw in the context of heavily-stratified programs. It attempted to maintain the export index as a stream, which meant that it would occasionally discard impactful changes or emit paradoxical changes. To fix this, we simply hold on to all exported facts until the entire transaction has completed, and then manage the export index post-collapse. Thanks to @thSoft for catching and reporting the issue and @ibdknox for helping me discard a very large number of red herrings.