### PR TITLE
Add a custom error message for values without attributes in a record

### DIFF
--- a/src/parser/parser.ts
+++ b/src/parser/parser.ts
@@ -794,6 +794,27 @@ export class Parser extends chev.Parser {
         {ALT: () => { return self.SUBRULE(self.attributeComparison); }},
         {ALT: () => { return self.SUBRULE(self.attributeNot, [recordVariable]); }},
         {ALT: () => { return self.SUBRULE(self.singularAttribute); }},
+        {ALT: () => {
+          let value: any = self.SUBRULE(self.value);
+          let token = value.from[0];
+
+          let message = "Value missing attribute";
+
+          if (value.hasOwnProperty("value")) {
+            message = `"${value.value}" needs to be labeled with an attribute`;
+          }
+
+          self.customErrors.push({
+            message,
+            name: "Unlabeled value",
+            resyncedTokens: [],
+            context: {
+              ruleOccurrenceStack: [],
+              ruleStack: []
+            },
+            token
+          });
+        }},
       ]);
     });
 


### PR DESCRIPTION
This implements part of the feature request in #436. It adds a slightly friendlier error message that appears when a value without an attribute in a record. For example, this code

```
search
  twenty = [-20]
bind
  [#ui/text text: twenty]
```

will generate the error message `"-20" needs to be labeled with an attribute`.

After this, the `attribute` rule could be modified to take another argument specifying whether the record that is being parsed is part of a `functionRecord`. If so, the message could mention that function syntax requires arguments to be labeled, and include parameter names if it is a standard library function. I can work on that next, if this looks good to you.