### PR TITLE
quickfix to delegate svg/root to the html watcher like canvas

### DIFF
--- a/src/watchers/dom.ts
+++ b/src/watchers/dom.ts
@@ -17,7 +17,8 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
 
   abstract tagPrefix:string;
   abstract createInstance(id:RawValue, element:RawValue, tagname:RawValue):Instance;
-  abstract createRoot(id:RawValue):Instance;
+  abstract getInstance(id:RawValue):Instance|undefined;
+  abstract createRoot(id:RawValue):Instance|undefined;
   abstract addAttribute(instance:Instance, attribute:RawValue, value:RawValue|boolean):void;
   abstract removeAttribute(instance:Instance, attribute:RawValue, value:RawValue|boolean):void;
 
@@ -40,11 +41,6 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
     if(!this.elementToInstances[element]) this.elementToInstances[element] = [];
     this.elementToInstances[element]!.push(id);
     return instance;
-  }
-
-  getInstance(id:RawValue, tagname:RawValue = "div"):Instance|undefined {
-    if(this.roots[id]) return this.roots[id]!;
-    return this.instances[id];
   }
 
   clearInstance(id:RawValue) {
@@ -134,7 +130,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
   }
 
   removeStyleInstance(styleId:RawValue, instanceId:RawValue) {
-    let instance = this.instances[instanceId];
+    let instance = this.getInstance(instanceId);
     if(!instance) return;
     instance.removeAttribute("style");
     let ix = instance.__styles!.indexOf(styleId);
@@ -278,7 +274,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
       })
       .asDiffs((diff) => {
         for(let [e, a, v] of diff.removes) {
-          let instance = this.instances[e];
+          let instance = this.getInstance(e);
           if(!instance) continue;
 
           if(a === "tagname") continue;
@@ -291,7 +287,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
         }
 
         for(let [e, a, v] of diff.adds) {
-          let instance = this.instances[e];
+          let instance = this.getInstance(e);
           if(!instance) throw new Error(`Orphaned instance '${e}'`);
 
           else if((a === "tagname")) continue;
@@ -314,7 +310,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
       })
       .asDiffs((diff) => {
         for(let [e, a, v] of diff.removes) {
-          let instance = this.instances[e];
+          let instance = this.getInstance(e);
           if(!instance) continue;
 
           for(let klass of (""+v).split(" ")) {
@@ -324,7 +320,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
         }
 
         for(let [e, a, v] of diff.adds) {
-          let instance = this.instances[e];
+          let instance = this.getInstance(e);
           if(!instance) throw new Error(`Orphaned instance '${e}'`);
 
           for(let klass of (""+v).split(" ")) {

--- a/src/watchers/html.ts
+++ b/src/watchers/html.ts
@@ -19,12 +19,19 @@ export class HTMLWatcher extends DOMWatcher<Instance> {
   }
 
   createInstance(id:RawValue, element:RawValue, tagname:RawValue):Instance {
-    let elem:Instance = document.createElement(tagname as string);
+    let elem:Instance
+    if(tagname === "svg") elem = document.createElementNS("http://www.w3.org/2000/svg", tagname as string) as any;
+    else elem = document.createElement(tagname as string);
+
     elem.setAttribute("instance", ""+maybeIntern(id));
     elem.setAttribute("element", ""+maybeIntern(element));
     elem.__element = element;
     elem.__styles = [];
     return elem;
+  }
+
+  getInstance(id:RawValue):Instance|undefined {
+    return this.instances[id];
   }
 
   createRoot(id:RawValue):Instance {

--- a/src/watchers/svg.ts
+++ b/src/watchers/svg.ts
@@ -23,6 +23,7 @@ class SVGWatcher extends DOMWatcher<Instance> {
 
   createRoot(id:RawValue) {
     // This is delegated to the HTML watcher for #svg/roots, and it's nonsensical to try to make any other svg element a root.
+    return undefined;
   }
 
   addAttribute(instance:Instance, attribute:RawValue, value:RawValue):void {


### PR DESCRIPTION
* Enables using `html.addExternalRoot()` to control SVG placement
* Enables mixing SVG into html documents, a feature I'd embarrassingly forgotten that the previous SVG library lacked.
* This fix is robust, but the original DOM library abstraction is really creaking here, it's worth revisiting in the future. This is especially the case since UI performance can be easily improved by an order of magnitude or more by not mirroring the instances back into Eve. In 0.4, this isn't really an issue, but 0.3 could really benefit from the boost.