### PR TITLE
Prevent exception from program which parses to no code blocks

### DIFF
--- a/src/runtime/dsl2.ts
+++ b/src/runtime/dsl2.ts
@@ -1892,6 +1892,8 @@ export class Program {
     this.attach("ui");
     this.attach("html");
     this.attach("compiler");
-    this.inputEAVs(results.results.eavs);
+    if(results.results.eavs.length) {
+      this.inputEAVs(results.results.eavs);
+    }
   }
 }


### PR DESCRIPTION
Program.inputEAVs throws an exception when the input eav array is empty, so Program.load shouldn't call it when no code blocks are returned from parsing the document.