### PR TITLE
only group console logs if possible

### DIFF
--- a/src/watchers/compiler.ts
+++ b/src/watchers/compiler.ts
@@ -286,10 +286,12 @@ export class CompilerWatcher extends Watcher {
         this.programToInjectInto.asDiffs(func);
       }
     }
-    console.groupCollapsed("Compiled: " + block.name);
-    console.log(block, flow);
-    console.log(printBlock(block));
-    console.groupEnd();
+    if(console.groupCollapsed) {
+      console.groupCollapsed("Compiled: " + block.name);
+      console.log(block, flow);
+      console.log(printBlock(block));
+      console.groupEnd();
+    }
     return block;
   }
 


### PR DESCRIPTION
Debug printing was preventing native Eve program compilation in headless mode because `groupCollapsed()` is not a defined function in that context.