### PR TITLE
Enhance/native bridge support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export {Watcher, Program, appendAsEAVs, RawEAV, RawValue, RawMap, createId} from "./watchers/watcher";
+export {Watcher, Program, appendAsEAVs, RawEAV, RawEAVC, RawValue, RawMap, RawRecord, createId, EAVDiffs, Diffs} from "./watchers/watcher";
 export {parseDoc} from "./parser/parser";
 
 export var watcherPath = "./build/src/watchers";

--- a/src/watchers/dom.ts
+++ b/src/watchers/dom.ts
@@ -22,7 +22,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
   abstract addAttribute(instance:Instance, attribute:RawValue, value:RawValue|boolean):void;
   abstract removeAttribute(instance:Instance, attribute:RawValue, value:RawValue|boolean):void;
 
-  protected _dummy = document.createElement("div");
+  protected _dummy:HTMLElement;
 
   protected _sendEvent(eavs:(RawEAV|RawEAVC)[]) {
     this.program.inputEAVs(eavs);
@@ -167,6 +167,7 @@ export abstract class DOMWatcher<Instance extends ElemInstance> extends Watcher 
 
   setup() {
     if(typeof document === "undefined") return;
+    this._dummy = document.createElement("div");
 
     this.program
       .constants({tagPrefix: this.tagPrefix})

--- a/src/watchers/watcher.ts
+++ b/src/watchers/watcher.ts
@@ -215,7 +215,7 @@ export function isRecordSet(x:any): x is Attrs[] {
   return x && x.constructor === Array && isRecord(x[0]);
 }
 
-export interface Attrs extends RawMap<RawValue|RawValue[]|RawEAV[]|RawEAV[][]> {}
+export interface Attrs extends RawMap<RawValue|RawValue[]|RawEAV[]|RawEAV[][]|Attrs|Attrs[]> {}
 export function appendAsEAVs(eavs:any[], record: Attrs, id = createId()) {
   for(let attr in record) {
     let value = record[attr];


### PR DESCRIPTION
- Exports some additional types to make working with Eve more pleasant from typescript projects
- Fixes headless evaluation of programs relying on the DOM library (a recent change attempted to use the document prior to the in-browser check)
- Fixes the type definition of appendAsEAVs -- support for sub-records was added a while back, but the types were not updated to reflect this.