### PR TITLE
Add a function that lets you join strings together

### DIFF
--- a/src/runtime/stdlib.ts
+++ b/src/runtime/stdlib.ts
@@ -271,6 +271,16 @@ makeFunction({
 });
 
 makeFunction({
+  name: "string/join",
+  args: {},
+  variadic: true,
+  returns: {result: "string"},
+  apply: (values:string[], delimiter:string) => {
+    return [values.join(delimiter)];
+  }
+});
+
+makeFunction({
   name: "string/get",
   args: {text: "string", at: "number"},
   returns: {result: "string"},


### PR DESCRIPTION
The function `string/join` would be very useful to be able to join multiple strings together via a delimiter like a space or comma.