### PR TITLE
Update autocomplete sorting

### DIFF
--- a/src/watchers/ui.ts
+++ b/src/watchers/ui.ts
@@ -403,10 +403,13 @@ export class UIWatcher extends Watcher {
         return [autocomplete.add("match", completion)];
       })
 
-      .bind("Matches are sorted by length.", ({find, lib:{string}}) => {
+      .bind("Matches are sorted by length by default.", ({find, lib:{string}}) => {
         let autocomplete = find("ui/autocomplete");
         let {match} = autocomplete;
+        let sortby = autocomplete.sortby;
         let sort = string["codepoint-length"](match.text);
+        if (sortby === "alpha")
+          sort = match.text
         return [match.add("sort", sort)];
       })
 


### PR DESCRIPTION
Autocomplete now has the ability to **sort matches by the alphabet** as well as the default by length. The way this is done is by adding another value to your autocomplete called `sortby`. If `sortby: "alpha"` then it sorts the matches by the alphabet. Not sure if this works 100%; modification is probably needed.